### PR TITLE
fix: issue where game crashes on init due to unknown preference

### DIFF
--- a/dev-only/story/Config.yaml
+++ b/dev-only/story/Config.yaml
@@ -55,5 +55,4 @@ userPreferences:
   autoSpeed: 150
   bgmv: 0.8
   sfxv: 0.5
-  voicesv: 0.2
   muted: false

--- a/src/core/UserPreferences.ts
+++ b/src/core/UserPreferences.ts
@@ -57,9 +57,11 @@ export default class UserPreferences {
 
     setPreferences(preferences){
         if (preferences) {
-            for (var preference in preferences) {
-                // set the raw value
-                this.preferences[preference].value = preferences[preference]
+            for (var preference in this.preferences) {
+                if (preferences[preference] !== undefined) {
+                    // set the raw value
+                    this.preferences[preference].value = preferences[preference];
+                }
             }
         }
     }


### PR DESCRIPTION
Currently, the `setPreferences` call goes through preferences passed in as a parameter and sets the values on `this.preferences`, but if one does not already exist on the class member, it will error out due to trying to access `.value` of `undefined`. This changes it to loop through the current preferences, and only try to apply the ones also found on the parameter.

Also removed the `voicesv` preference from the config in the test stories (it's unused and what prompted the error).