### PR TITLE
fix: interactive elements rendered underneath dialogue

### DIFF
--- a/src/gui/RJSHUD.ts
+++ b/src/gui/RJSHUD.ts
@@ -6,7 +6,7 @@ import MessageBox from './elements/MessageBox'
 import NameBox from './elements/NameBox'
 import ChoiceHandler from './elements/ChoiceHandler'
 
-import {changeInputEnabled} from '../utils/gui'
+import { changeInputEnabled, hudSort } from '../utils/gui';
 
 export default class RJSHUD extends RJSMenu {
     mBoxes = {}
@@ -18,7 +18,7 @@ export default class RJSHUD extends RJSMenu {
     
 
     constructor(game: RJS, config) {
-        super(game, config);
+        super(game, config.slice().sort(hudSort));
         // add factories for hud specific elements
         this.elementFactory = Object.assign(this.elementFactory,{
             messageBox: this.createMessageBox.bind(this),

--- a/src/utils/gui.ts
+++ b/src/utils/gui.ts
@@ -72,3 +72,21 @@ export function toHexColor(color) {
     // eslint-disable-next-line no-bitwise
     return (parseInt(color.substr(1), 16) << 8) / 256;
 }
+
+/**
+ * compareFn for hud config elements.
+ * ensures that name box is on top of dialogue,
+ * and that choices and buttons are on top of both
+ */
+export function hudSort(a: { type: string }, b: { type: string }) {
+  const order = [
+    'messageBox',
+    'nameBox',
+    'button',
+    'choices',
+  ];
+  const idxA = order.indexOf(a.type);
+  const idxB = order.indexOf(b.type);
+  if (idxA === undefined || idxB === undefined) return 0;
+  return idxA - idxB;
+}


### PR DESCRIPTION
fixes #34

The order of HUD elements is currently defined by the GUI config, which results in choices being rendered underneath dialogue if both are on screen. This adds a sort to the GUI config before the elements are created to help avoid overlap issues.