### PR TITLE
fix: choice without action throwing error

### DIFF
--- a/src/managers/LogicManager.ts
+++ b/src/managers/LogicManager.ts
@@ -104,7 +104,7 @@ export default class LogicManager implements LogicManagerInterface<Group> {
         let rawText = Object.keys(choice)[0];
         const parsedChoice:any = {
             index: index,
-            actions: choice[rawText],
+            actions: choice[rawText] || [],
             available: true,
             choiceText: this.parseVars(rawText),
             previouslyChosen: this.choiceInLog(index)


### PR DESCRIPTION
fixes #33

includes an empty array as choice actions if there are none when parsing to avoid errors downstream