### PR TITLE
fix: calling `hide` on a background freezing game

### DIFF
--- a/src/core/actions/StoryActionHide.ts
+++ b/src/core/actions/StoryActionHide.ts
@@ -18,8 +18,8 @@ export default class StoryActionHide extends StoryAction {
             transitioning = this.game.managers.cgs.hideAll(this.params.transition)
         } else if (this.params.actor === 'ALL') {
             transitioning = Promise.all([
-            	this.game.managers.background.hide(this.params.transition), 
-            	this.game.managers.character.hideAll(this.params.transition), 
+            	this.game.managers.background.hide(undefined, this.params.transition),
+            	this.game.managers.character.hideAll(this.params.transition),
             	this.game.managers.cgs.hideAll(this.params.transition)
         	]);
         } else {

--- a/src/managers/BackgroundManager.ts
+++ b/src/managers/BackgroundManager.ts
@@ -54,7 +54,7 @@ export default class BackgroundManager implements RJSSpriteManagerInterface {
     }
 
     async hide (bg?: string, transitionName = 'FADEOUT'): Promise<void> {
-        await this.show(null,transitionName);
+        if(!bg || bg === this.current?.name) await this.show(null,transitionName);
     }
 
     isBackground (actor: string): boolean {

--- a/src/managers/BackgroundManager.ts
+++ b/src/managers/BackgroundManager.ts
@@ -54,7 +54,7 @@ export default class BackgroundManager implements RJSSpriteManagerInterface {
     }
 
     async hide (bg?: string, transitionName = 'FADEOUT'): Promise<void> {
-        if(!bg || bg === this.current?.name) await this.show(null,transitionName);
+        if(this.current && (!bg || bg === this.current.name)) await this.show(null,transitionName);
     }
 
     isBackground (actor: string): boolean {

--- a/src/managers/BackgroundManager.ts
+++ b/src/managers/BackgroundManager.ts
@@ -1,20 +1,10 @@
-import {RJSSpriteManagerInterface} from './RJSManager';
-import {Group} from 'phaser-ce';
-import Transition from '../screen-effects/Transition';
+import { Sprite } from 'phaser-ce';
 import RJS from '../core/RJS';
+import { RJSSpriteManagerInterface } from './RJSManager';
 
-export interface BackgroundManagerInterface<T> extends RJSSpriteManagerInterface {
-    backgrounds: object;
-    current?: object;
-    createBackground(name): void;
-    show (name, transitionName): any;
-    hide (bg,transitionName): any;
-    isBackground (actor): boolean;
-}
-
-export default class BackgroundManager implements BackgroundManagerInterface<Group> {
-    backgrounds = {};
-    current = null;
+export default class BackgroundManager implements RJSSpriteManagerInterface {
+    backgrounds: { [key: string]: string } = {};
+    current?: Sprite;
 
     constructor(private game: RJS) {
         if (game.setup.backgrounds){
@@ -22,26 +12,25 @@ export default class BackgroundManager implements BackgroundManagerInterface<Gro
         }
     }
 
-    createBackground(name): void {
+    createBackground(name: string): Sprite {
         const str = this.backgrounds[name].split(' ');
-        const pos = this.game.storyConfig.positions.BACKGROUND ? 
+        const pos = this.game.storyConfig.positions.BACKGROUND ?
                 this.game.storyConfig.positions.BACKGROUND :
                 {x:this.game.world.centerX, y:this.game.world.centerY};
-        let bg = this.game.managers.story.backgroundSprites.create(pos.x,pos.y, name);
+        const bg: Sprite = this.game.managers.story.backgroundSprites.create(pos.x,pos.y, name);
         bg.alpha = 0;
         bg.visible = false;
         bg.name = name;
         bg.anchor.set(0.5);
-        if (str.length != 1){
+        if (str.length !== 1){
             const framerate = str.length === 4 ? parseInt(str[3], 10) : 16;
-            bg.animated = true;
             bg.animations.add('run', null, framerate);
             bg.animations.play('run', null, true);
         }
         return bg
     }
 
-    set (name): void {
+    set (name: string): void {
         if (this.current){
             this.current.destroy();
         }
@@ -54,7 +43,7 @@ export default class BackgroundManager implements BackgroundManagerInterface<Gro
         this.current.visible = true;
     }
 
-    async show (name, transitionName): Promise<any> {
+    async show (name: string, transitionName: string): Promise<void> {
         const oldBg = this.current;
         this.current = name ? this.createBackground(name) : null;
         if (this.current){
@@ -64,11 +53,11 @@ export default class BackgroundManager implements BackgroundManagerInterface<Gro
         if (oldBg) oldBg.destroy();
     }
 
-    async hide (bg?, transitionName = 'FADEOUT'): Promise<any> {
-        return this.show(null,transitionName);
+    async hide (bg?: string, transitionName = 'FADEOUT'): Promise<void> {
+        await this.show(null,transitionName);
     }
 
-    isBackground (actor): boolean {
+    isBackground (actor: string): boolean {
         return actor in this.backgrounds;
     }
 }


### PR DESCRIPTION
fixes #29

Cleans up the typescript in the background manager, and fixes issue where promise chain gets stuck in a state it can't resolve due to trying to hide a background that isn't currently shown. Trying to hide a background which is not the current one will now do nothing, allowing the game to continue. The behaviour for hiding any bg regardless of what name was passed in is still supported, but only for explicitly passing in a falsey name.

Also fixes bug in "hide all" where transition wasn't respected due to incorrect parameters being passed in.