### PR TITLE
fix: update text displays immediately when changing text

### DIFF
--- a/src/gui/elements/ChoiceHandler.ts
+++ b/src/gui/elements/ChoiceHandler.ts
@@ -73,7 +73,7 @@ export default class ChoiceHandler extends Graphics {
         chBox.y += separation;
         chBox.setFrames(...getButtonFrames(chBox.animations.frameTotal))
         const text = new Label(this.game,this.config.text,chBox);
-        text.text = setTextStyles(choice.choiceText,text);
+        text.setText(setTextStyles(choice.choiceText,text), true);
         chBox.addChild(text);
         
         if (choice.previouslyChosen){

--- a/src/gui/elements/Label.ts
+++ b/src/gui/elements/Label.ts
@@ -25,7 +25,7 @@ export default class Label extends Text {
           this.setTextBounds(this.x,this.y,parent.width,parent.height)
         }
         if (this.config.text){
-            this.text = setTextStyles(this.config.text,this);
+            this.setText(setTextStyles(this.config.text,this), true);
         }
     }
 

--- a/src/gui/elements/MessageBox.ts
+++ b/src/gui/elements/MessageBox.ts
@@ -100,7 +100,7 @@ export default class MessageBox extends Sprite{
         let finalText = setTextStyles(text,this.text);
         let textSpeed:number = this.game.userPreferences.get('textSpeed');
         if (this.game.control.skipping || textSpeed < 10){
-            this.text.text = finalText;
+            this.text.setText(finalText, true);
             this.visible = true;
             this.alpha = 1;
             if (this.ctc){
@@ -108,7 +108,7 @@ export default class MessageBox extends Sprite{
             }
             return;
         }
-        this.text.text = '';
+        this.text.setText('', true);
         
         // add new line characters at the end of each line
         if (this.game.storyConfig.precomputeBreakLines){
@@ -140,7 +140,7 @@ export default class MessageBox extends Sprite{
                 // text finished showing, clear timeout
                 clearTimeout(this.textLoop);
                 // complete text in case of skipping
-                this.text.text = finalText;
+                this.text.setText(finalText, true);
                 // show ctc
                 if (this.ctc){
                     this.ctc.visible = true;
@@ -221,7 +221,7 @@ export default class MessageBox extends Sprite{
         if(!this.config.alwaysOn){
             await this.hide(transitionName)
         }
-        this.text.text = '';
+        this.text.setText('', true);
         if (this.ctc){
             this.ctc.visible = false;
         }

--- a/src/gui/elements/NameBox.ts
+++ b/src/gui/elements/NameBox.ts
@@ -38,6 +38,7 @@ export default class NameBox extends Sprite {
 
     async show(text,color) {
         this.text.setText(text, true);
+        this.text.updateTransform();
         if (this.config.tintStyle == 'box'){
             this.tint = toHexColor(color);
         } else {

--- a/src/gui/elements/NameBox.ts
+++ b/src/gui/elements/NameBox.ts
@@ -37,7 +37,7 @@ export default class NameBox extends Sprite {
     }
 
     async show(text,color) {
-        this.text.text = text;
+        this.text.setText(text, true);
         if (this.config.tintStyle == 'box'){
             this.tint = toHexColor(color);
         } else {

--- a/src/gui/elements/NameBox.ts
+++ b/src/gui/elements/NameBox.ts
@@ -55,7 +55,7 @@ export default class NameBox extends Sprite {
         let transition = this.game.screenEffects.transition.get(transitionName);
         await transition(this,null);
         this.visible = false;
-        this.text.text = '';
+        this.text.setText('', true);
     }
 
     destroy(): void {

--- a/src/screen-effects/Effects.ts
+++ b/src/screen-effects/Effects.ts
@@ -42,6 +42,7 @@ export default class Effects implements RJSScreenEffectInterface {
             }
         }
         const timePerLine = params.timePerLine ? params.timePerLine : 1500;
+        credits.updateTransform();
         
         return new Promise(resolve => {
             this.tweenManager.tween(credits, {y: -(separation * params.text.length + 30)}, async ()=>{

--- a/src/screen-effects/Effects.ts
+++ b/src/screen-effects/Effects.ts
@@ -36,7 +36,7 @@ export default class Effects implements RJSScreenEffectInterface {
         for (let i = 1; i < params.text.length; i++) {
             if (params.text[i]) {
                 const nextLine = this.game.add.text(0, i * separation,'', style);
-                nextLine.text = setTextStyles(params.text[i],nextLine);
+                nextLine.setText(setTextStyles(params.text[i],nextLine), true);
                 nextLine.anchor.set(0.5);
                 credits.addChild(nextLine);
             }


### PR DESCRIPTION
Attempt at improving issues described in #32.

This definitely doesn't totally resolve the issues (doesn't even touch the images part), but it does seem to reduce the flicker on the namebox/dialogue. I'm still not 100% sure what the root cause is, but it seems to be a bug in Phaser's implementation of text bounds: if you remove the `boundsAlign` properties from the config. the flicker goes away entirely. I did find a seemingly related issue on their repo (https://github.com/photonstorm/phaser-ce/issues/518) but unfortunately it looks like it was closed without any particular resolution.

I tested by including the following at the top of `NameBox.show`:
```ts
requestAnimationFrame(() => {
    requestAnimationFrame(() => {
        debugger;
    });
});
```
Prior to this change, the `debugger` would catch the text out of position 100% of the time:
![image](https://user-images.githubusercontent.com/6496840/139561842-72ab74ee-3198-4da5-a178-d833a81e4924.png)
![image](https://user-images.githubusercontent.com/6496840/139561857-3b542c3b-9173-404d-8cee-2c187dbffbdc.png)

After this change, it will sometimes still catch it out of position, but significantly less often, and only ever in the latter case where it's seemingly left-aligned, but otherwise correctly positioned.