### PR TITLE
fix: background flickering for one frame when shown

### DIFF
--- a/src/managers/BackgroundManager.ts
+++ b/src/managers/BackgroundManager.ts
@@ -28,6 +28,7 @@ export default class BackgroundManager implements BackgroundManagerInterface<Gro
                 this.game.storyConfig.positions.BACKGROUND :
                 {x:this.game.world.centerX, y:this.game.world.centerY};
         let bg = this.game.managers.story.backgroundSprites.create(pos.x,pos.y, name);
+        bg.updateTransform();
         bg.alpha = 0;
         bg.visible = false;
         bg.name = name;


### PR DESCRIPTION
partial fix for #32 

OK i think i have a slightly better understanding of the bug here: there's a few different performance optimizations in Phaser which are interfering with positioning logic. The bounds are only updated during rendering, which means anything that references the bounds (e.g. positioning) will be incorrect on the frame that they are created unless you explicitly call `updateTransform()`.

In addition to that, `updateTransform` includes a check for visibility and early returns instead of actually updating the transform if the object is hidden, so in a case like this, the order needs to specifically be:

```js
const thing = thing.create();
thing.updateTransform();
thing.visible = false;
```

To test this one, I found that you can pretty easily repro the bg flicker with a script that just loads a bg, waits a frame, then swaps to another on repeat (definitely hard on the eyes and an epilepsy trigger though), e.g.

```yaml
start:
  - show room_night:
  - wait: 1
  - show room_night_light:
  - wait: 1
  - scene: start
```