### PR TITLE
fix: loading screen starting full before starting at zero

### DIFF
--- a/src/states/Boot.ts
+++ b/src/states/Boot.ts
@@ -55,7 +55,8 @@ class Boot extends RJSState {
     }
 
     create (game: RJS): void {
-        new RJSLoadingScreen(this.game);
+        const loadingScreen = new RJSLoadingScreen(this.game);
+        loadingScreen.setLoadingBar(this.game);
         this.input.onDown.addOnce(()=> {
             if (this.sound.context.state === 'suspended') {
                 this.sound.context.resume();


### PR DESCRIPTION
fixes another minor flicker issue noticed while debugging fonts (which may be exaggerated by the font fix): the "boot" state shows a copy of the loading screen, but never sets the loading bar, so it shows the bar full for a brief period before starting over at zero for the "preload" state