### PR TITLE
fix: font preloading

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -91,6 +91,12 @@
       "integrity": "sha512-OCutwjDZ4aFS6PB1UZ988C4YgwlBHJd6wCeQqaLdmadZ/7e+w79+hbMUFC1QXDNCmdyoRfAFdm0RypzwR+Qpag==",
       "dev": true
     },
+    "@types/fontfaceobserver": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@types/fontfaceobserver/-/fontfaceobserver-2.1.0.tgz",
+      "integrity": "sha512-Vqf183RAiFdIjUi4asKqogf2HIfLDnxn+dQo9GCpnsU5QrrsLMA2bkJU1dHRudQlizLybWD61Csd1zAgUQ3JKQ==",
+      "dev": true
+    },
     "@types/glob": {
       "version": "7.1.3",
       "resolved": "https://registry.npmjs.org/@types/glob/-/glob-7.1.3.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -3180,6 +3180,11 @@
       "integrity": "sha512-aq6gF1BEKje4a9i9+5jimNFIpq4Q1WiwBToeRK5NvZBd/TRsmW8BsJfOEGkr76TbOyPVD3OVDN910EcUNtRYEA==",
       "dev": true
     },
+    "fontfaceobserver": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fontfaceobserver/-/fontfaceobserver-2.1.0.tgz",
+      "integrity": "sha512-ReOsO2F66jUa0jmv2nlM/s1MiutJx/srhAe2+TE8dJCMi02ZZOcCTxTCQFr3Yet+uODUtnr4Mewg+tNQ+4V1Ng=="
+    },
     "for-in": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "webpack-merge": "^5.1.1"
   },
   "dependencies": {
+    "fontfaceobserver": "^2.1.0",
     "js-yaml": "^3.14.0",
     "object-hash": "^2.0.3",
     "phaser-ce": "^2.16.0"

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
   },
   "homepage": "https://github.com/lunafromthemoon/RenJS#readme",
   "devDependencies": {
+    "@types/fontfaceobserver": "^2.1.0",
     "@types/js-yaml": "^3.12.5",
     "@typescript-eslint/eslint-plugin": "^2.34.0",
     "@typescript-eslint/parser": "^3.9.1",

--- a/src/states/Boot.ts
+++ b/src/states/Boot.ts
@@ -89,7 +89,7 @@ class Boot extends RJSState {
 
         // preload the fonts by adding text, else they wont be fully loaded :\
         const families = game.gui.fonts;
-        const styles = ['normal', 'italic', 'oblique'];
+        const styles = ['normal', 'italic'];
         const weights = ['normal', 'bold'];
         for (const family of families) {
             for (const style of styles) {

--- a/src/states/Boot.ts
+++ b/src/states/Boot.ts
@@ -1,7 +1,7 @@
 import jsyaml from 'js-yaml'
 import {loadStyle, preparePath} from './utils';
 import RJSState from './RJSState';
-import {Sprite} from 'phaser-ce';
+import {Sprite, Text} from 'phaser-ce';
 import PreloadStory from './PreloadStory';
 import RJSGUIByBuilder from '../gui/RJSGUIByBuilder';
 import RJSGUIByNewBuilder from '../gui/RJSGUIByNewBuilder';
@@ -87,16 +87,21 @@ class Boot extends RJSState {
             console.error("Check the docs at http://renjs.net/docs-page.html")
         }
 
-        for (const font of game.gui.fonts) {
-            if (game.config.debugMode) {
-                console.log('Preloading the font ' + font + ' by adding hidden text'); // Else they wont be fully loaded and show FOUT
+        // preload the fonts by adding text, else they wont be fully loaded :\
+        const families = game.gui.fonts;
+        const styles = ['normal', 'italic', 'oblique'];
+        const weights = ['normal', 'bold'];
+        for (const family of families) {
+            for (const style of styles) {
+                for (const weight of weights) {
+                    const font = `${style} ${weight} 1px ${family}`;
+                    if (game.config.debugMode) {
+                        console.log(`Preloading the font "${font}" by adding hidden text`);
+                    }
+                    const t = new Text(game, 0, 0, ' ', { font });
+                    t.destroy();
+                }
             }
-            game.add.text(20, -100, font, { font: 'normal normal 42px ' + font });
-            game.add.text(20, -100, font, { font: 'normal bold 42px ' + font });
-            game.add.text(20, -100, font, { font: 'italic normal 42px ' + font });
-            game.add.text(20, -100, font, { font: 'italic bold 42px ' + font });
-            game.add.text(20, -100, font, { font: 'oblique normal 42px ' + font });
-            game.add.text(20, -100, font, { font: 'oblique bold 42px ' + font });
         }
         game.state.add('preloadStory', PreloadStory);
         game.state.start('preloadStory');

--- a/src/states/Boot.ts
+++ b/src/states/Boot.ts
@@ -54,7 +54,7 @@ class Boot extends RJSState {
         }
     }
 
-    async create (game: RJS): Promise<void> {
+    create (game: RJS): void {
         new RJSLoadingScreen(this.game);
         this.input.onDown.addOnce(()=> {
             if (this.sound.context.state === 'suspended') {

--- a/src/states/Boot.ts
+++ b/src/states/Boot.ts
@@ -1,8 +1,7 @@
 import jsyaml from 'js-yaml'
-import FontFaceObserver from 'fontfaceobserver';
 import {loadStyle, preparePath} from './utils';
 import RJSState from './RJSState';
-import {Sprite, Text} from 'phaser-ce';
+import {Sprite} from 'phaser-ce';
 import PreloadStory from './PreloadStory';
 import RJSGUIByBuilder from '../gui/RJSGUIByBuilder';
 import RJSGUIByNewBuilder from '../gui/RJSGUIByNewBuilder';
@@ -88,26 +87,6 @@ class Boot extends RJSState {
             console.error("Check the docs at http://renjs.net/docs-page.html")
         }
 
-        // preload the fonts by adding text, else they wont be fully loaded :\
-        const families = game.gui.fonts;
-        const styles = ['normal', 'italic'];
-        const weights = ['normal', 'bold'];
-        const observers = [];
-        for (const family of families) {
-            for (const style of styles) {
-                for (const weight of weights) {
-                    const o = new FontFaceObserver(family, { weight, style });
-                    if (game.config.debugMode) {
-                        console.log('Preloading font', o);
-                    }
-                    observers.push(o.load().catch((err) => {
-                        console.warn('Font not available', o, err);
-                    }));
-                }
-            }
-        }
-
-        await Promise.all(observers);
         game.state.add('preloadStory', PreloadStory);
         game.state.start('preloadStory');
     }

--- a/src/states/PreloadStory.ts
+++ b/src/states/PreloadStory.ts
@@ -1,3 +1,4 @@
+import FontFaceObserver from 'fontfaceobserver';
 import {preparePath} from './utils';
 import {preloadBackground, preloadCGS, preloadAudio, preloadCharacter, preloadExtra} from './utils';
 import RJSState from './RJSState';
@@ -38,6 +39,24 @@ class PreloadStory extends RJSState {
                 this.game.load[asset.type](asset.key, preparePath(asset.file, this.game));
             }
         }
+
+        // preload fonts
+        const families = this.game.gui.fonts;
+        const styles = ['normal', 'italic'];
+        const weights = ['normal', 'bold'];
+        for (const family of families) {
+            for (const style of styles) {
+                for (const weight of weights) {
+                    const key = `${family} ${weight} ${style}`;
+                    this.game.load.addToFileList('font', key, '');
+                    const { file } = this.game.load.getAsset('font', key);
+                    new FontFaceObserver(family, { weight, style }).load()
+                        .then(() => this.game.load.asyncComplete(file))
+                        .catch((err) => this.game.load.asyncComplete(file, err));
+                }
+            }
+        }
+
         if (this.game.setup.lazyloading){
             // when lazy loading, game assets will be loaded while playing the story
             return


### PR DESCRIPTION
Adds font preloading via `fontfaceobserver` and some slightly hacky manipulation of the phaser loader file list to make sure font loading is included as part of preload state + loading bar. Replaces previous font preload strategy where fonts were assumed to be loaded by rendering off-screen text during boot.

includes a refactor of the fix in #27 that adds bold + italic to preloaded fonts (note that oblique has been removed since renjs doesn't actually support oblique in the story markup).