### PR TITLE
fix: `RJSGUI.menus` being incorrectly initialized due to typescript error

### DIFF
--- a/src/gui/RJSGUI.ts
+++ b/src/gui/RJSGUI.ts
@@ -22,7 +22,7 @@ export default class RJSGUI implements RJSGUIInterface {
     assets: GUIAsset[] = []
     fonts: string[] = []
     // gui graphical elements
-    menus = {string:RJSMenu};
+    menus: { [key: string]: RJSMenu } = {};
     hud: RJSHUD = null;
 
     // menu navigation


### PR DESCRIPTION
this appears to be a type notation that was unintentionally written as a default value, creating `RJSGUI.menus.string` as a reference to the `RJSMenu` class instead of defining the type of `RJSGUI.menus`

note: caught this in a lint pass, but it's a functional change so putting it up as a separate PR