### PR TITLE
fix: fix missing radix when parsing thumbnail properties

### DIFF
--- a/src/gui/RJSGUIByBuilder.ts
+++ b/src/gui/RJSGUIByBuilder.ts
@@ -113,10 +113,10 @@ export default class RJSGUIByBuilder extends RJSGUIByNewBuilder {
                       asset:element.id,
                       slot: element.slot,
                       thumbnail: {
-                          x: parseInt(element['thumbnail-x']),
-                          y: parseInt(element['thumbnail-y']),
-                          width: parseInt(element['thumbnail-width']),
-                          height: parseInt(element['thumbnail-height']),
+                          x: parseInt(element['thumbnail-x'], 10),
+                          y: parseInt(element['thumbnail-y'], 10),
+                          width: parseInt(element['thumbnail-width'], 10),
+                          height: parseInt(element['thumbnail-height'], 10),
                       }
                   }
                   menuConfig.push(saveSlot);


### PR DESCRIPTION
this only affects older js, but can cause issues in parsing: `parseInt` used to automatically parse as octal if the number string started with a zero, so it's recommended to always specify the radix

note: caught this in a lint pass, but it's a functional change so putting it up as a separate PR