### PR TITLE
chore: use SPDX license abbreviation instead of full text

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "RockDaFox",
     "Sean S. LeBlanc"
   ],
-  "license": "Creative Commons Attribution Share Alike 4.0 International",
+  "license": "CC-BY-SA-4.0",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/lunafromthemoon/RenJS-V2.git"


### PR DESCRIPTION
npm seems to prefer the short form; fixes a warning on install:
```sh
npm WARN renjs@2.3.2 license should be a valid SPDX license expression
```