### PR TITLE
stack-based text style

### DIFF
--- a/dev-only/story/test/TestStory.yaml
+++ b/dev-only/story/test/TestStory.yaml
@@ -184,8 +184,8 @@ testtext:
   - deuzi says angry:  Lorem ipsum dolor sit amet, consectetur adipiscing elit... Aasdf qwer! asdfasdf.
   - liz says happy: asdf qwer asdf 
   - text:  Text with styles
-  - text: This is (italic)italic(end), this is (bold)bold(end).
-  - text: Text can have (color:red)color(end) too. With hex (color:#f593e6)this is pink(end).
+  - text: This is (italic)italic(end), this is (bold)bold(end). This is (italic)italic (bold)and(end) bold(end).
+  - text: Text can have (color:red)color(end) too. With hex (color:#f593e6)this is pink(end). This is (italic)italic (color:red)and(end) red(end).
   - deuzi says normal: Praesent finibus nunc id mauris ullamcorper fermentum. Mauris faucibus eu sem in aliquet. 
   - show liz: AT OUTLEFT WITH CUT
     flipped: true

--- a/src/utils/textStyle.ts
+++ b/src/utils/textStyle.ts
@@ -3,7 +3,7 @@ type Token = { text: string; tag?: never } | { text?: never; tag: string };
 const re = /\((?:color:(?:\w+|#[0-9a-fA-F]{3}|#[0-9a-fA-F]{6})|italic|bold|end)\)/;
 
 /** converts text into a list of tokens that can be used to construct styles */
-export function tokenizeTextStyle(text: string) {
+export function tokenizeTextStyle(text: string): Token[] {
 	const styles: Token[] = [];
 	while (true) {
 		const match = re.exec(text);

--- a/src/utils/textStyle.ts
+++ b/src/utils/textStyle.ts
@@ -1,0 +1,19 @@
+type Token = { text: string; tag?: never } | { text?: never; tag: string };
+
+const re = /\((?:color:(?:\w+|#[0-9a-fA-F]{3}|#[0-9a-fA-F]{6})|italic|bold|end)\)/;
+
+/** converts text into a list of tokens that can be used to construct styles */
+export function tokenizeTextStyle(text: string) {
+	const styles: Token[] = [];
+	while (true) {
+		const match = re.exec(text);
+		if (!match) {
+			styles.push({ text });
+			return styles;
+		}
+		const { index, 0: tag } = match;
+		styles.push({ text: text.substr(0, index) });
+		styles.push({ tag: tag.slice(1, -1) });
+		text = text.substr(index + tag.length);
+	}
+}


### PR DESCRIPTION
refactors the text style to use a stack-based approach so that `(end)` tags will close the last opened style rather than having tags lookahead to find an `(end)` (i needed to refactor this so semantic html could be created on my a11y draft, and figured the ingame text style improvement would be worth pulling out as a separate change)

Note that the regex has been changed to be slightly more specific too so that invalid hex colours (i.e. ones which are not actually 0-f, or are not 3/6 digits long) will be ignored.

Example of a case this addresses (added to the demo):
```yml
  - text: Text can have (color:red)color(end) too. With hex (color:#f593e6)this is pink(end). This is (italic)italic (color:red)and(end) red(end).
```

Before:
![image](https://user-images.githubusercontent.com/6496840/144696688-4aa80b46-1164-423c-b82d-bed0d2111280.png)

After:
![image](https://user-images.githubusercontent.com/6496840/144696690-6857af80-8863-4d4d-953e-31f1405464df.png)


