### PR TITLE
add accessibilty layer

### DIFF
--- a/RenJSQuickstart/story/GUI.yaml
+++ b/RenJSQuickstart/story/GUI.yaml
@@ -64,12 +64,6 @@ config:
       'y': 468
       asset: asset22
     - type: button
-      x: 688
-      'y': 474
-      asset: asset23
-      binding: openMenu
-      menu: saveload
-    - type: button
       x: 646
       'y': 474
       asset: asset24
@@ -77,14 +71,20 @@ config:
       menu: settings
     - type: button
       x: 688
-      'y': 514
-      asset: asset25
-      binding: skip
+      'y': 474
+      asset: asset23
+      binding: openMenu
+      menu: saveload
     - type: button
       x: 646
       'y': 514
       asset: asset26
       binding: auto
+    - type: button
+      x: 688
+      'y': 514
+      asset: asset25
+      binding: skip
   menus:
     main:
       - type: image

--- a/RenJSQuickstart/story/GUI.yaml
+++ b/RenJSQuickstart/story/GUI.yaml
@@ -244,46 +244,46 @@ config:
           boundsAlignH: left
           boundsAlignV: top
       - type: button
+        x: 120
+        'y': 340
+        asset: asset39
+        binding: save
+        slot: '0'
+      - type: button
+        x: 120
+        'y': 408
+        asset: asset40
+        binding: load
+        slot: '0'
+      - type: button
+        x: 353
+        'y': 340
+        asset: asset39
+        binding: save
+        slot: '1'
+      - type: button
+        x: 353
+        'y': 408
+        asset: asset40
+        binding: load
+        slot: '1'
+      - type: button
+        x: 580
+        'y': 340
+        asset: asset39
+        binding: save
+        slot: '2'
+      - type: button
+        x: 580
+        'y': 408
+        asset: asset40
+        binding: load
+        slot: '2'
+      - type: button
         x: 616
         'y': 506
         asset: asset17
         binding: return
-      - type: button
-        x: 120
-        'y': 340
-        asset: asset39
-        binding: save
-        slot: '0'
-      - type: button
-        x: 120
-        'y': 408
-        asset: asset40
-        binding: load
-        slot: '0'
-      - type: button
-        x: 353
-        'y': 340
-        asset: asset39
-        binding: save
-        slot: '1'
-      - type: button
-        x: 353
-        'y': 408
-        asset: asset40
-        binding: load
-        slot: '1'
-      - type: button
-        x: 580
-        'y': 340
-        asset: asset39
-        binding: save
-        slot: '2'
-      - type: button
-        x: 580
-        'y': 408
-        asset: asset40
-        binding: load
-        slot: '2'
 assets:
   images:
     loaderbackground:

--- a/dev-only/story/GUI.yaml
+++ b/dev-only/story/GUI.yaml
@@ -152,15 +152,6 @@ config:
         x: 640
         assetType: images
     buttons:
-      - id: asset23
-        sfx: none
-        slot: '0'
-        binding: saveload
-        height: '39'
-        width: '41'
-        'y': 474
-        x: 688
-        assetType: spritesheets
       - id: asset24
         sfx: none
         slot: '0'
@@ -170,13 +161,13 @@ config:
         'y': 474
         x: 646
         assetType: spritesheets
-      - id: asset25
+      - id: asset23
         sfx: none
         slot: '0'
-        binding: skip
+        binding: saveload
         height: '39'
         width: '41'
-        'y': 514
+        'y': 474
         x: 688
         assetType: spritesheets
       - id: asset26
@@ -187,6 +178,15 @@ config:
         width: '41'
         'y': 514
         x: 646
+        assetType: spritesheets
+      - id: asset25
+        sfx: none
+        slot: '0'
+        binding: skip
+        height: '39'
+        width: '41'
+        'y': 514
+        x: 688
         assetType: spritesheets
     choice:
       id: asset31

--- a/dev-only/story/GUI.yaml
+++ b/dev-only/story/GUI.yaml
@@ -237,6 +237,60 @@ config:
         font: fontsaudimat-mono
         color: '#B0B0B0'
     buttons:
+      - id: asset39
+        sfx: none
+        slot: '0'
+        binding: save
+        height: '53'
+        width: '103'
+        'y': 340
+        x: 120
+        assetType: spritesheets
+      - id: asset40
+        sfx: none
+        slot: '0'
+        binding: load
+        height: '53'
+        width: '103'
+        'y': 408
+        x: 120
+        assetType: spritesheets
+      - id: asset39
+        sfx: none
+        slot: '1'
+        binding: save
+        height: '53'
+        width: '103'
+        'y': 340
+        x: 353
+        assetType: spritesheets
+      - id: asset40
+        sfx: none
+        slot: '1'
+        binding: load
+        height: '53'
+        width: '103'
+        'y': 408
+        x: 353
+        assetType: spritesheets
+      - id: asset39
+        sfx: none
+        slot: '2'
+        binding: save
+        height: '53'
+        width: '103'
+        'y': 340
+        x: 580
+        assetType: spritesheets
+      - id: asset40
+        sfx: none
+        slot: '2'
+        binding: load
+        height: '53'
+        width: '103'
+        'y': 408
+        x: 580
+        assetType: spritesheets
       - id: asset17
         sfx: none
         slot: '0'
@@ -245,60 +299,6 @@ config:
         width: '163'
         'y': 506
         x: 616
-        assetType: spritesheets
-      - id: asset39
-        sfx: none
-        slot: '0'
-        binding: save
-        height: '53'
-        width: '103'
-        'y': 340
-        x: 120
-        assetType: spritesheets
-      - id: asset40
-        sfx: none
-        slot: '0'
-        binding: load
-        height: '53'
-        width: '103'
-        'y': 408
-        x: 120
-        assetType: spritesheets
-      - id: asset39
-        sfx: none
-        slot: '1'
-        binding: save
-        height: '53'
-        width: '103'
-        'y': 340
-        x: 353
-        assetType: spritesheets
-      - id: asset40
-        sfx: none
-        slot: '1'
-        binding: load
-        height: '53'
-        width: '103'
-        'y': 408
-        x: 353
-        assetType: spritesheets
-      - id: asset39
-        sfx: none
-        slot: '2'
-        binding: save
-        height: '53'
-        width: '103'
-        'y': 340
-        x: 580
-        assetType: spritesheets
-      - id: asset40
-        sfx: none
-        slot: '2'
-        binding: load
-        height: '53'
-        width: '103'
-        'y': 408
-        x: 580
         assetType: spritesheets
     save-slots:
       - id: asset18

--- a/dev-only/story/NewGUI.yaml
+++ b/dev-only/story/NewGUI.yaml
@@ -64,12 +64,6 @@ config:
       'y': 468
       asset: asset22
     - type: button
-      x: 688
-      'y': 474
-      asset: asset23
-      binding: openMenu
-      menu: saveload
-    - type: button
       x: 646
       'y': 474
       asset: asset24
@@ -77,14 +71,20 @@ config:
       menu: settings
     - type: button
       x: 688
-      'y': 514
-      asset: asset25
-      binding: skip
+      'y': 474
+      asset: asset23
+      binding: openMenu
+      menu: saveload
     - type: button
       x: 646
       'y': 514
       asset: asset26
       binding: auto
+    - type: button
+      x: 688
+      'y': 514
+      asset: asset25
+      binding: skip
   menus:
     main:
       - type: image

--- a/dev-only/story/NewGUI.yaml
+++ b/dev-only/story/NewGUI.yaml
@@ -244,46 +244,46 @@ config:
           boundsAlignH: left
           boundsAlignV: top
       - type: button
+        x: 120
+        'y': 340
+        asset: asset39
+        binding: save
+        slot: '0'
+      - type: button
+        x: 120
+        'y': 408
+        asset: asset40
+        binding: load
+        slot: '0'
+      - type: button
+        x: 353
+        'y': 340
+        asset: asset39
+        binding: save
+        slot: '1'
+      - type: button
+        x: 353
+        'y': 408
+        asset: asset40
+        binding: load
+        slot: '1'
+      - type: button
+        x: 580
+        'y': 340
+        asset: asset39
+        binding: save
+        slot: '2'
+      - type: button
+        x: 580
+        'y': 408
+        asset: asset40
+        binding: load
+        slot: '2'
+      - type: button
         x: 616
         'y': 506
         asset: asset17
         binding: return
-      - type: button
-        x: 120
-        'y': 340
-        asset: asset39
-        binding: save
-        slot: '0'
-      - type: button
-        x: 120
-        'y': 408
-        asset: asset40
-        binding: load
-        slot: '0'
-      - type: button
-        x: 353
-        'y': 340
-        asset: asset39
-        binding: save
-        slot: '1'
-      - type: button
-        x: 353
-        'y': 408
-        asset: asset40
-        binding: load
-        slot: '1'
-      - type: button
-        x: 580
-        'y': 340
-        asset: asset39
-        binding: save
-        slot: '2'
-      - type: button
-        x: 580
-        'y': 408
-        asset: asset40
-        binding: load
-        slot: '2'
 assets:
   images:
     loaderbackground:

--- a/dev-only/story/i18n/en/GUI.yaml
+++ b/dev-only/story/i18n/en/GUI.yaml
@@ -161,15 +161,6 @@ config:
         x: 640
         assetType: images
     buttons:
-      - id: asset23
-        sfx: none
-        slot: '0'
-        binding: saveload
-        height: '39'
-        width: '41'
-        'y': 474
-        x: 688
-        assetType: spritesheets
       - id: asset24
         sfx: none
         slot: '0'
@@ -179,13 +170,13 @@ config:
         'y': 474
         x: 646
         assetType: spritesheets
-      - id: asset25
+      - id: asset23
         sfx: none
         slot: '0'
-        binding: skip
+        binding: saveload
         height: '39'
         width: '41'
-        'y': 514
+        'y': 474
         x: 688
         assetType: spritesheets
       - id: asset26
@@ -196,6 +187,15 @@ config:
         width: '41'
         'y': 514
         x: 646
+        assetType: spritesheets
+      - id: asset25
+        sfx: none
+        slot: '0'
+        binding: skip
+        height: '39'
+        width: '41'
+        'y': 514
+        x: 688
         assetType: spritesheets
     choice:
       id: asset31

--- a/dev-only/story/i18n/en/GUI.yaml
+++ b/dev-only/story/i18n/en/GUI.yaml
@@ -246,6 +246,60 @@ config:
         font: fontsaudimat-mono
         color: '#B0B0B0'
     buttons:
+      - id: asset39
+        sfx: none
+        slot: '0'
+        binding: save
+        height: '53'
+        width: '103'
+        'y': 340
+        x: 120
+        assetType: spritesheets
+      - id: asset40
+        sfx: none
+        slot: '0'
+        binding: load
+        height: '53'
+        width: '103'
+        'y': 408
+        x: 120
+        assetType: spritesheets
+      - id: asset39
+        sfx: none
+        slot: '1'
+        binding: save
+        height: '53'
+        width: '103'
+        'y': 340
+        x: 353
+        assetType: spritesheets
+      - id: asset40
+        sfx: none
+        slot: '1'
+        binding: load
+        height: '53'
+        width: '103'
+        'y': 408
+        x: 353
+        assetType: spritesheets
+      - id: asset39
+        sfx: none
+        slot: '2'
+        binding: save
+        height: '53'
+        width: '103'
+        'y': 340
+        x: 580
+        assetType: spritesheets
+      - id: asset40
+        sfx: none
+        slot: '2'
+        binding: load
+        height: '53'
+        width: '103'
+        'y': 408
+        x: 580
+        assetType: spritesheets
       - id: asset17
         sfx: none
         slot: '0'
@@ -254,60 +308,6 @@ config:
         width: '163'
         'y': 506
         x: 616
-        assetType: spritesheets
-      - id: asset39
-        sfx: none
-        slot: '0'
-        binding: save
-        height: '53'
-        width: '103'
-        'y': 340
-        x: 120
-        assetType: spritesheets
-      - id: asset40
-        sfx: none
-        slot: '0'
-        binding: load
-        height: '53'
-        width: '103'
-        'y': 408
-        x: 120
-        assetType: spritesheets
-      - id: asset39
-        sfx: none
-        slot: '1'
-        binding: save
-        height: '53'
-        width: '103'
-        'y': 340
-        x: 353
-        assetType: spritesheets
-      - id: asset40
-        sfx: none
-        slot: '1'
-        binding: load
-        height: '53'
-        width: '103'
-        'y': 408
-        x: 353
-        assetType: spritesheets
-      - id: asset39
-        sfx: none
-        slot: '2'
-        binding: save
-        height: '53'
-        width: '103'
-        'y': 340
-        x: 580
-        assetType: spritesheets
-      - id: asset40
-        sfx: none
-        slot: '2'
-        binding: load
-        height: '53'
-        width: '103'
-        'y': 408
-        x: 580
         assetType: spritesheets
     save-slots:
       - id: asset18

--- a/dev-only/story/i18n/es/GUI.yaml
+++ b/dev-only/story/i18n/es/GUI.yaml
@@ -253,15 +253,6 @@ config:
         font: fontsaudimat-mono
         color: '#B0B0B0'
     buttons:
-      - id: asset51
-        sfx: none
-        slot: '0'
-        binding: return
-        height: '82'
-        width: '163'
-        'y': '506'
-        x: '616'
-        assetType: spritesheets
       - id: asset52
         sfx: none
         slot: '0'
@@ -315,6 +306,15 @@ config:
         width: '145'
         'y': '408'
         x: 561
+        assetType: spritesheets
+      - id: asset51
+        sfx: none
+        slot: '0'
+        binding: return
+        height: '82'
+        width: '163'
+        'y': '506'
+        x: '616'
         assetType: spritesheets
     save-slot:
       id: asset18

--- a/dev-only/story/i18n/es/GUI.yaml
+++ b/dev-only/story/i18n/es/GUI.yaml
@@ -168,15 +168,6 @@ config:
         x: 640
         assetType: images
     buttons:
-      - id: asset23
-        sfx: none
-        slot: '0'
-        binding: saveload
-        height: '39'
-        width: '41'
-        'y': 474
-        x: 688
-        assetType: spritesheets
       - id: asset24
         sfx: none
         slot: '0'
@@ -186,13 +177,13 @@ config:
         'y': 474
         x: 646
         assetType: spritesheets
-      - id: asset25
+      - id: asset23
         sfx: none
         slot: '0'
-        binding: skip
+        binding: saveload
         height: '39'
         width: '41'
-        'y': 514
+        'y': 474
         x: 688
         assetType: spritesheets
       - id: asset26
@@ -203,6 +194,15 @@ config:
         width: '41'
         'y': 514
         x: 646
+        assetType: spritesheets
+      - id: asset25
+        sfx: none
+        slot: '0'
+        binding: skip
+        height: '39'
+        width: '41'
+        'y': 514
+        x: 688
         assetType: spritesheets
     choice:
       id: asset31

--- a/dev-only/story/multipleboxes/GUI.yaml
+++ b/dev-only/story/multipleboxes/GUI.yaml
@@ -321,46 +321,46 @@ config:
           boundsAlignH: left
           boundsAlignV: top
       - type: button
+        x: 120
+        'y': 340
+        asset: asset39
+        binding: save
+        slot: '0'
+      - type: button
+        x: 120
+        'y': 408
+        asset: asset40
+        binding: load
+        slot: '0'
+      - type: button
+        x: 353
+        'y': 340
+        asset: asset39
+        binding: save
+        slot: '1'
+      - type: button
+        x: 353
+        'y': 408
+        asset: asset40
+        binding: load
+        slot: '1'
+      - type: button
+        x: 580
+        'y': 340
+        asset: asset39
+        binding: save
+        slot: '2'
+      - type: button
+        x: 580
+        'y': 408
+        asset: asset40
+        binding: load
+        slot: '2'
+      - type: button
         x: 616
         'y': 506
         asset: asset17
         binding: return
-      - type: button
-        x: 120
-        'y': 340
-        asset: asset39
-        binding: save
-        slot: '0'
-      - type: button
-        x: 120
-        'y': 408
-        asset: asset40
-        binding: load
-        slot: '0'
-      - type: button
-        x: 353
-        'y': 340
-        asset: asset39
-        binding: save
-        slot: '1'
-      - type: button
-        x: 353
-        'y': 408
-        asset: asset40
-        binding: load
-        slot: '1'
-      - type: button
-        x: 580
-        'y': 340
-        asset: asset39
-        binding: save
-        slot: '2'
-      - type: button
-        x: 580
-        'y': 408
-        asset: asset40
-        binding: load
-        slot: '2'
 assets:
   images:
     loaderbackground:

--- a/dev-only/story/multipleboxes/GUI.yaml
+++ b/dev-only/story/multipleboxes/GUI.yaml
@@ -141,12 +141,6 @@ config:
       'y': 468
       asset: asset22
     - type: button
-      x: 688
-      'y': 474
-      asset: asset23
-      binding: openMenu
-      menu: saveload
-    - type: button
       x: 646
       'y': 474
       asset: asset24
@@ -154,14 +148,20 @@ config:
       menu: settings
     - type: button
       x: 688
-      'y': 514
-      asset: asset25
-      binding: skip
+      'y': 474
+      asset: asset23
+      binding: openMenu
+      menu: saveload
     - type: button
       x: 646
       'y': 514
       asset: asset26
       binding: auto
+    - type: button
+      x: 688
+      'y': 514
+      asset: asset25
+      binding: skip
   menus:
     main:
       - type: image

--- a/dev-only/story/test/TestStory.yaml
+++ b/dev-only/story/test/TestStory.yaml
@@ -184,8 +184,8 @@ testtext:
   - deuzi says angry:  Lorem ipsum dolor sit amet, consectetur adipiscing elit... Aasdf qwer! asdfasdf.
   - liz says happy: asdf qwer asdf 
   - text:  Text with styles
-  - text: This is (italic)italic(end), this is (bold)bold(end).
-  - text: Text can have (color:red)color(end) too. With hex (color:#f593e6)this is pink(end).
+  - text: This is (italic)italic(end), this is (bold)bold(end). This is (italic)italic (bold)and(end) bold(end).
+  - text: Text can have (color:red)color(end) too. With hex (color:#f593e6)this is pink(end). This is (italic)italic (color:red)and(end) red(end).
   - deuzi says normal: Praesent finibus nunc id mauris ullamcorper fermentum. Mauris faucibus eu sem in aliquet. 
   - show liz: AT OUTLEFT WITH CUT
     flipped: true

--- a/docs/examples/GUI.yaml
+++ b/docs/examples/GUI.yaml
@@ -64,12 +64,6 @@ config:
       'y': 468
       asset: asset22
     - type: button
-      x: 688
-      'y': 474
-      asset: asset23
-      binding: openMenu
-      menu: saveload
-    - type: button
       x: 646
       'y': 474
       asset: asset24
@@ -77,14 +71,20 @@ config:
       menu: settings
     - type: button
       x: 688
-      'y': 514
-      asset: asset25
-      binding: skip
+      'y': 474
+      asset: asset23
+      binding: openMenu
+      menu: saveload
     - type: button
       x: 646
       'y': 514
       asset: asset26
       binding: auto
+    - type: button
+      x: 688
+      'y': 514
+      asset: asset25
+      binding: skip
   menus:
     main:
       - type: image

--- a/docs/examples/GUI.yaml
+++ b/docs/examples/GUI.yaml
@@ -244,46 +244,46 @@ config:
           boundsAlignH: left
           boundsAlignV: top
       - type: button
+        x: 120
+        'y': 340
+        asset: asset39
+        binding: save
+        slot: '0'
+      - type: button
+        x: 120
+        'y': 408
+        asset: asset40
+        binding: load
+        slot: '0'
+      - type: button
+        x: 353
+        'y': 340
+        asset: asset39
+        binding: save
+        slot: '1'
+      - type: button
+        x: 353
+        'y': 408
+        asset: asset40
+        binding: load
+        slot: '1'
+      - type: button
+        x: 580
+        'y': 340
+        asset: asset39
+        binding: save
+        slot: '2'
+      - type: button
+        x: 580
+        'y': 408
+        asset: asset40
+        binding: load
+        slot: '2'
+      - type: button
         x: 616
         'y': 506
         asset: asset17
         binding: return
-      - type: button
-        x: 120
-        'y': 340
-        asset: asset39
-        binding: save
-        slot: '0'
-      - type: button
-        x: 120
-        'y': 408
-        asset: asset40
-        binding: load
-        slot: '0'
-      - type: button
-        x: 353
-        'y': 340
-        asset: asset39
-        binding: save
-        slot: '1'
-      - type: button
-        x: 353
-        'y': 408
-        asset: asset40
-        binding: load
-        slot: '1'
-      - type: button
-        x: 580
-        'y': 340
-        asset: asset39
-        binding: save
-        slot: '2'
-      - type: button
-        x: 580
-        'y': 408
-        asset: asset40
-        binding: load
-        slot: '2'
 assets:
   images:
     loaderbackground:

--- a/docs/examples/i18n/en/GUI.yaml
+++ b/docs/examples/i18n/en/GUI.yaml
@@ -161,15 +161,6 @@ config:
         x: 640
         assetType: images
     buttons:
-      - id: asset23
-        sfx: none
-        slot: '0'
-        binding: saveload
-        height: '39'
-        width: '41'
-        'y': 474
-        x: 688
-        assetType: spritesheets
       - id: asset24
         sfx: none
         slot: '0'
@@ -179,13 +170,13 @@ config:
         'y': 474
         x: 646
         assetType: spritesheets
-      - id: asset25
+      - id: asset23
         sfx: none
         slot: '0'
-        binding: skip
+        binding: saveload
         height: '39'
         width: '41'
-        'y': 514
+        'y': 474
         x: 688
         assetType: spritesheets
       - id: asset26
@@ -196,6 +187,15 @@ config:
         width: '41'
         'y': 514
         x: 646
+        assetType: spritesheets
+      - id: asset25
+        sfx: none
+        slot: '0'
+        binding: skip
+        height: '39'
+        width: '41'
+        'y': 514
+        x: 688
         assetType: spritesheets
     choice:
       id: asset31

--- a/docs/examples/i18n/en/GUI.yaml
+++ b/docs/examples/i18n/en/GUI.yaml
@@ -246,6 +246,60 @@ config:
         font: fontsaudimat-mono
         color: '#B0B0B0'
     buttons:
+      - id: asset39
+        sfx: none
+        slot: '0'
+        binding: save
+        height: '53'
+        width: '103'
+        'y': 340
+        x: 120
+        assetType: spritesheets
+      - id: asset40
+        sfx: none
+        slot: '0'
+        binding: load
+        height: '53'
+        width: '103'
+        'y': 408
+        x: 120
+        assetType: spritesheets
+      - id: asset39
+        sfx: none
+        slot: '1'
+        binding: save
+        height: '53'
+        width: '103'
+        'y': 340
+        x: 353
+        assetType: spritesheets
+      - id: asset40
+        sfx: none
+        slot: '1'
+        binding: load
+        height: '53'
+        width: '103'
+        'y': 408
+        x: 353
+        assetType: spritesheets
+      - id: asset39
+        sfx: none
+        slot: '2'
+        binding: save
+        height: '53'
+        width: '103'
+        'y': 340
+        x: 580
+        assetType: spritesheets
+      - id: asset40
+        sfx: none
+        slot: '2'
+        binding: load
+        height: '53'
+        width: '103'
+        'y': 408
+        x: 580
+        assetType: spritesheets
       - id: asset17
         sfx: none
         slot: '0'
@@ -254,60 +308,6 @@ config:
         width: '163'
         'y': 506
         x: 616
-        assetType: spritesheets
-      - id: asset39
-        sfx: none
-        slot: '0'
-        binding: save
-        height: '53'
-        width: '103'
-        'y': 340
-        x: 120
-        assetType: spritesheets
-      - id: asset40
-        sfx: none
-        slot: '0'
-        binding: load
-        height: '53'
-        width: '103'
-        'y': 408
-        x: 120
-        assetType: spritesheets
-      - id: asset39
-        sfx: none
-        slot: '1'
-        binding: save
-        height: '53'
-        width: '103'
-        'y': 340
-        x: 353
-        assetType: spritesheets
-      - id: asset40
-        sfx: none
-        slot: '1'
-        binding: load
-        height: '53'
-        width: '103'
-        'y': 408
-        x: 353
-        assetType: spritesheets
-      - id: asset39
-        sfx: none
-        slot: '2'
-        binding: save
-        height: '53'
-        width: '103'
-        'y': 340
-        x: 580
-        assetType: spritesheets
-      - id: asset40
-        sfx: none
-        slot: '2'
-        binding: load
-        height: '53'
-        width: '103'
-        'y': 408
-        x: 580
         assetType: spritesheets
     save-slots:
       - id: asset18

--- a/docs/examples/i18n/es/GUI.yaml
+++ b/docs/examples/i18n/es/GUI.yaml
@@ -253,15 +253,6 @@ config:
         font: fontsaudimat-mono
         color: '#B0B0B0'
     buttons:
-      - id: asset51
-        sfx: none
-        slot: '0'
-        binding: return
-        height: '82'
-        width: '163'
-        'y': '506'
-        x: '616'
-        assetType: spritesheets
       - id: asset52
         sfx: none
         slot: '0'
@@ -315,6 +306,15 @@ config:
         width: '145'
         'y': '408'
         x: 561
+        assetType: spritesheets
+      - id: asset51
+        sfx: none
+        slot: '0'
+        binding: return
+        height: '82'
+        width: '163'
+        'y': '506'
+        x: '616'
         assetType: spritesheets
     save-slot:
       id: asset18

--- a/docs/examples/i18n/es/GUI.yaml
+++ b/docs/examples/i18n/es/GUI.yaml
@@ -168,15 +168,6 @@ config:
         x: 640
         assetType: images
     buttons:
-      - id: asset23
-        sfx: none
-        slot: '0'
-        binding: saveload
-        height: '39'
-        width: '41'
-        'y': 474
-        x: 688
-        assetType: spritesheets
       - id: asset24
         sfx: none
         slot: '0'
@@ -186,13 +177,13 @@ config:
         'y': 474
         x: 646
         assetType: spritesheets
-      - id: asset25
+      - id: asset23
         sfx: none
         slot: '0'
-        binding: skip
+        binding: saveload
         height: '39'
         width: '41'
-        'y': 514
+        'y': 474
         x: 688
         assetType: spritesheets
       - id: asset26
@@ -203,6 +194,15 @@ config:
         width: '41'
         'y': 514
         x: 646
+        assetType: spritesheets
+      - id: asset25
+        sfx: none
+        slot: '0'
+        binding: skip
+        height: '39'
+        width: '41'
+        'y': 514
+        x: 688
         assetType: spritesheets
     choice:
       id: asset31

--- a/docs/examples/multiboxportraits/GUI.yaml
+++ b/docs/examples/multiboxportraits/GUI.yaml
@@ -321,46 +321,46 @@ config:
           boundsAlignH: left
           boundsAlignV: top
       - type: button
+        x: 120
+        'y': 340
+        asset: asset39
+        binding: save
+        slot: '0'
+      - type: button
+        x: 120
+        'y': 408
+        asset: asset40
+        binding: load
+        slot: '0'
+      - type: button
+        x: 353
+        'y': 340
+        asset: asset39
+        binding: save
+        slot: '1'
+      - type: button
+        x: 353
+        'y': 408
+        asset: asset40
+        binding: load
+        slot: '1'
+      - type: button
+        x: 580
+        'y': 340
+        asset: asset39
+        binding: save
+        slot: '2'
+      - type: button
+        x: 580
+        'y': 408
+        asset: asset40
+        binding: load
+        slot: '2'
+      - type: button
         x: 616
         'y': 506
         asset: asset17
         binding: return
-      - type: button
-        x: 120
-        'y': 340
-        asset: asset39
-        binding: save
-        slot: '0'
-      - type: button
-        x: 120
-        'y': 408
-        asset: asset40
-        binding: load
-        slot: '0'
-      - type: button
-        x: 353
-        'y': 340
-        asset: asset39
-        binding: save
-        slot: '1'
-      - type: button
-        x: 353
-        'y': 408
-        asset: asset40
-        binding: load
-        slot: '1'
-      - type: button
-        x: 580
-        'y': 340
-        asset: asset39
-        binding: save
-        slot: '2'
-      - type: button
-        x: 580
-        'y': 408
-        asset: asset40
-        binding: load
-        slot: '2'
 assets:
   images:
     loaderbackground:

--- a/docs/examples/multiboxportraits/GUI.yaml
+++ b/docs/examples/multiboxportraits/GUI.yaml
@@ -141,12 +141,6 @@ config:
       'y': 468
       asset: asset22
     - type: button
-      x: 688
-      'y': 474
-      asset: asset23
-      binding: openMenu
-      menu: saveload
-    - type: button
       x: 646
       'y': 474
       asset: asset24
@@ -154,14 +148,20 @@ config:
       menu: settings
     - type: button
       x: 688
-      'y': 514
-      asset: asset25
-      binding: skip
+      'y': 474
+      asset: asset23
+      binding: openMenu
+      menu: saveload
     - type: button
       x: 646
       'y': 514
       asset: asset26
       binding: auto
+    - type: button
+      x: 688
+      'y': 514
+      asset: asset25
+      binding: skip
   menus:
     main:
       - type: image

--- a/docs/examples/tutorial/GUI.yaml
+++ b/docs/examples/tutorial/GUI.yaml
@@ -64,12 +64,6 @@ config:
       'y': 468
       asset: asset22
     - type: button
-      x: 688
-      'y': 474
-      asset: asset23
-      binding: openMenu
-      menu: saveload
-    - type: button
       x: 646
       'y': 474
       asset: asset24
@@ -77,14 +71,20 @@ config:
       menu: settings
     - type: button
       x: 688
-      'y': 514
-      asset: asset25
-      binding: skip
+      'y': 474
+      asset: asset23
+      binding: openMenu
+      menu: saveload
     - type: button
       x: 646
       'y': 514
       asset: asset26
       binding: auto
+    - type: button
+      x: 688
+      'y': 514
+      asset: asset25
+      binding: skip
   menus:
     main:
       - type: image

--- a/docs/examples/tutorial/GUI.yaml
+++ b/docs/examples/tutorial/GUI.yaml
@@ -244,46 +244,46 @@ config:
           boundsAlignH: left
           boundsAlignV: top
       - type: button
+        x: 120
+        'y': 340
+        asset: asset39
+        binding: save
+        slot: '0'
+      - type: button
+        x: 120
+        'y': 408
+        asset: asset40
+        binding: load
+        slot: '0'
+      - type: button
+        x: 353
+        'y': 340
+        asset: asset39
+        binding: save
+        slot: '1'
+      - type: button
+        x: 353
+        'y': 408
+        asset: asset40
+        binding: load
+        slot: '1'
+      - type: button
+        x: 580
+        'y': 340
+        asset: asset39
+        binding: save
+        slot: '2'
+      - type: button
+        x: 580
+        'y': 408
+        asset: asset40
+        binding: load
+        slot: '2'
+      - type: button
         x: 616
         'y': 506
         asset: asset17
         binding: return
-      - type: button
-        x: 120
-        'y': 340
-        asset: asset39
-        binding: save
-        slot: '0'
-      - type: button
-        x: 120
-        'y': 408
-        asset: asset40
-        binding: load
-        slot: '0'
-      - type: button
-        x: 353
-        'y': 340
-        asset: asset39
-        binding: save
-        slot: '1'
-      - type: button
-        x: 353
-        'y': 408
-        asset: asset40
-        binding: load
-        slot: '1'
-      - type: button
-        x: 580
-        'y': 340
-        asset: asset39
-        binding: save
-        slot: '2'
-      - type: button
-        x: 580
-        'y': 408
-        asset: asset40
-        binding: load
-        slot: '2'
 assets:
   images:
     loaderbackground:

--- a/src/core/RJS.ts
+++ b/src/core/RJS.ts
@@ -5,6 +5,7 @@ import RJSControl from './RJSControl';
 import ExecStack from './ExecStack';
 import BackgroundManager from '../managers/BackgroundManager';
 import CharacterManager from '../managers/CharacterManager';
+import Accessibility from '../gui/a11y/Accessibility';
 import AudioManager from '../managers/AudioManager';
 import CGSManager from '../managers/CGSManager';
 import TextManager from '../managers/TextManager';
@@ -50,6 +51,7 @@ export default class RJS extends Game {
     config: RJSGameConfig
     userPreferences: UserPreferences
     storyConfig: StoryConfig
+    accessibility: Accessibility;
 
     textLog: any[] = []
 
@@ -88,6 +90,7 @@ export default class RJS extends Game {
         super(config.w,config.h,config.renderer, config.parent)
         this.control = new RJSControl();
         this.config = config;
+        this.accessibility = new Accessibility(this);
         // this.userPreferences = new UserPreferences(this);
     }
 

--- a/src/gui/RJSGUI.ts
+++ b/src/gui/RJSGUI.ts
@@ -73,6 +73,7 @@ export default class RJSGUI implements RJSGUIInterface {
         // this.game.pause();
         this.previousMenu = this.currentMenu;
         this.currentMenu = menu;
+        this.game.accessibility.updateLayout();
         this.game.world.bringToTop(this.menus[menu])
         await this.menus[menu].show();
     }
@@ -81,7 +82,9 @@ export default class RJSGUI implements RJSGUIInterface {
         if (!menu){
             menu = this.currentMenu;
         }
-        await this.menus[menu].hide(mute);
+        const p = this.menus[menu].hide(mute);
+        this.game.accessibility.updateLayout();
+        await p;
         this.currentMenu = null;
         if (callback){
             callback()

--- a/src/gui/RJSHUD.ts
+++ b/src/gui/RJSHUD.ts
@@ -1,5 +1,5 @@
 import RJS from '../core/RJS';
-import {Graphics,Color} from 'phaser-ce';
+import {Graphics,Color, Button} from 'phaser-ce';
 import RJSMenu from './RJSMenu'
 import MessageBox from './elements/MessageBox'
 import BaseButton from './elements/BaseButton'
@@ -7,6 +7,7 @@ import NameBox from './elements/NameBox'
 import ChoiceHandler from './elements/ChoiceHandler'
 
 import { changeInputEnabled, hudSort } from '../utils/gui';
+import { AccessibilityBounds } from './a11y/Accessibility';
 
 export default class RJSHUD extends RJSMenu {
     mBoxes = {}
@@ -110,15 +111,15 @@ export default class RJSHUD extends RJSMenu {
                     // TODO: better accessible label - this is just the texture name,
                     // not something necessarily meant to be user-facing
                     label: choice.choiceText.split(' AT ')[0],
-                    isActive: () => !this.game.control.unskippable && boxes[index].parent.parent === this.game.gui.menus[this.game.gui.currentMenu],
-                    onclick: () => resolve(index),
-                    getBounds: () => boxes[index].getBounds(),
+                    isActive: (): boolean => !this.game.control.unskippable && boxes[index].parent.parent === this.game.gui.menus[this.game.gui.currentMenu],
+                    onclick: (): void => resolve(index),
+                    getBounds: (): AccessibilityBounds => boxes[index].getBounds(),
                 }))
             );
         });
     }
 
-    createVisualChoice(choice, index, resolve) {
+    createVisualChoice(choice, index, resolve): Button {
         const defaultChoicesConfig = this.cHandlers.default.config;
         // visual choice text -> spriteId AT x,y|positionId SFX sfxId
         const str = choice.choiceText.split(' ');

--- a/src/gui/RJSMenu.ts
+++ b/src/gui/RJSMenu.ts
@@ -119,7 +119,7 @@ export default class RJSMenu extends Group {
             max: 1,
             step: 0.05,
             get: () => slider.currentValue,
-            set: (value) => slider.setValue(value),
+            set: (v) => slider.setValue(v),
             getBounds: () => {
                 const r = slider.getBounds();
                 r.x = slider.position.x;

--- a/src/gui/RJSMenu.ts
+++ b/src/gui/RJSMenu.ts
@@ -112,6 +112,21 @@ export default class RJSMenu extends Group {
             value = (preference.value-preference.min)/(preference.max - preference.min);
         }
         const slider = new MaskSlider(this.game,element,value);
+        this.game.accessibility.slider({
+            isActive: () => !this.game.control.unskippable && slider.parent === this.game.gui.menus[this.game.gui.currentMenu],
+            label: [element.binding, element.userPreference].filter(i => i).join(' '),
+            min: 0,
+            max: 1,
+            step: 0.05,
+            get: () => slider.currentValue,
+            set: (value) => slider.setValue(value),
+            getBounds: () => {
+                const r = slider.getBounds();
+                r.x = slider.position.x;
+                r.y = slider.position.y;
+                return r;
+            },
+        });
         return slider
     }
 

--- a/src/gui/RJSMenu.ts
+++ b/src/gui/RJSMenu.ts
@@ -65,19 +65,36 @@ export default class RJSMenu extends Group {
         asset: string;
         sfx: string;
         binding: string;
+        menu?: string;
+        slot?: number;
         pushButton?: boolean;
         pushed?: boolean;
     }): BaseButton {
+        let btn: BaseButton;
         if (element.pushButton){
-            const btn = new PushButton(this.game,element)
+            btn = new PushButton(this.game,element)
             if (element.binding === 'auto' || element.binding === 'skip'){
                 // auto and skip will be unset when tapping anywhere in the screen
                 // always index for changing state when this happens
                 this.indexedElements[element.binding+'Button'] = btn;
             }
-            return btn;
+        } else {
+            btn = new BaseButton(this.game,element);
         }
-        return new BaseButton(this.game,element)
+        this.game.accessibility.button({
+            isActive: () => !this.game.control.unskippable && btn.parent === this.game.gui.menus[this.game.gui.currentMenu],
+            label: [element.binding, element.menu, element.slot].filter(i => i).join(' '),
+            onclick: () => btn.onClick(),
+            onfocus: () => btn.frame = 1,
+            onblur: () => btn.frame = 0,
+            getBounds: () => {
+                const r = btn.getBounds();
+                r.x = btn.position.x;
+                r.y = btn.position.y;
+                return r;
+            },
+        });
+        return btn;
     }
 
     createSlider(element: {

--- a/src/gui/a11y/Accessibility.ts
+++ b/src/gui/a11y/Accessibility.ts
@@ -148,6 +148,7 @@ export default class Accessibility {
 	}
 
 	boot(): void {
+		this.game.canvas.setAttribute('aria-hidden', 'true');
 		this.game.scale.onSizeChange.add(this.updateLayout);
 		this.updateLayout();
 		this.game.load.onLoadStart.add(() => {

--- a/src/gui/a11y/Accessibility.ts
+++ b/src/gui/a11y/Accessibility.ts
@@ -304,7 +304,9 @@ export default class Accessibility {
 		input.style.left = '0';
 		input.style.width = '100%';
 		input.style.height = '100%';
-		input.setAttribute('appearance', 'none');
+		// eslint-disable-next-line @typescript-eslint/ban-ts-ignore
+		// @ts-ignore
+		input.style.appearance = 'textfield';
 		input.style.background = 'transparent';
 		if (this.debug) {
 			input.style.border = 'solid 1px red';

--- a/src/gui/a11y/Accessibility.ts
+++ b/src/gui/a11y/Accessibility.ts
@@ -1,23 +1,23 @@
 import RJS from '../../core/RJS';
 import { tokenizeTextStyle } from '../../utils/textStyle';
 
-interface Bounds {
+export interface AccessibilityBounds {
 	x: number;
 	y: number;
 	width: number;
 	height: number;
 }
 
-interface Button {
+export interface AccessibilityButton {
 	label?: string;
 	isActive: () => boolean;
 	onclick: HTMLButtonElement['onclick'];
 	onfocus?: HTMLButtonElement['onfocus'];
 	onblur?: HTMLButtonElement['onblur'];
-	getBounds: () => Bounds;
+	getBounds: () => AccessibilityBounds;
 }
 
-interface Slider {
+export interface AccessibilitySlider {
 	label?: string;
 	isActive: () => boolean;
 	min: number;
@@ -25,16 +25,16 @@ interface Slider {
 	step: number | 'any';
 	set: (value: number) => void;
 	get: () => number;
-	getBounds: () => Bounds;
+	getBounds: () => AccessibilityBounds;
 }
 
 /** sanitize strings for better screen-reading */
-function sanitize(str: string) {
+function sanitize(str: string): string {
 	return str.replace(/\s+/g, ' ').trim();
 }
 
 /** converts RenJS formatted text to an HTML markup string */
-function textToHtml(text: string) {
+function textToHtml(text: string): string {
 	const tokens = tokenizeTextStyle(text);
 	const tags = [];
 	let result = '';
@@ -78,9 +78,9 @@ export default class Accessibility {
 	state: {
 		name: string;
 		text: string;
-		choices: Button[];
-		buttons: Button[];
-		sliders: Slider[];
+		choices: AccessibilityButton[];
+		buttons: AccessibilityButton[];
+		sliders: AccessibilitySlider[];
 	} = {
 		name: '',
 		text: '',
@@ -120,7 +120,7 @@ export default class Accessibility {
 		this.elText.setAttribute('role', 'main');
 		this.elText.setAttribute('aria-roledescription', 'text');
 		this.elText.tabIndex = 0;
-		this.elText.onclick = () => {
+		this.elText.onclick = (): void => {
 			this.game.onTap(null);
 		};
 		this.elText.style.position = 'absolute';
@@ -147,7 +147,7 @@ export default class Accessibility {
 		this.elContainer.appendChild(this.elButtons);
 	}
 
-	boot() {
+	boot(): void {
 		this.game.scale.onSizeChange.add(this.updateLayout);
 		this.updateLayout();
 		this.game.load.onLoadStart.add(() => {
@@ -166,7 +166,7 @@ export default class Accessibility {
 		document.body.appendChild(this.elContainer);
 	}
 
-	progress(progress) {
+	progress(progress): void {
 		if (progress === undefined) {
 			delete this.elProgress.value;
 		} else {
@@ -174,15 +174,15 @@ export default class Accessibility {
 		}
 	}
 
-	busy() {
+	busy(): void {
 		this.elText.setAttribute('aria-busy', 'true');
 	}
 
-	ready() {
+	ready(): void {
 		this.elText.setAttribute('aria-busy', 'false');
 	}
 
-	updateLayoutText() {
+	updateLayoutText(): void {
 		let text = textToHtml(
 			this.game.gui?.currentMenu !== 'hud'
 				? ''
@@ -199,21 +199,21 @@ export default class Accessibility {
 		this.elText.innerHTML = text;
 	}
 
-	updateLayoutContainer() {
+	updateLayoutContainer(): void {
 		this.elContainer.style.width = `${this.game.scale.width}px`;
 		this.elContainer.style.height = `${this.game.scale.height}px`;
 		this.elContainer.style.top = `${this.game.scale.margin.top}px`;
 		this.elContainer.style.left = `${this.game.scale.margin.left}px`;
 	}
 
-	updateLayoutBounds(el: HTMLElement, rect: Bounds) {
+	updateLayoutBounds(el: HTMLElement, rect: AccessibilityBounds): void {
 		el.style.width = `${rect.width * this.game.scale.scaleFactorInversed.x}px`;
 		el.style.height = `${rect.height * this.game.scale.scaleFactorInversed.y}px`;
 		el.style.top = `${rect.y * this.game.scale.scaleFactorInversed.y}px`;
 		el.style.left = `${rect.x * this.game.scale.scaleFactorInversed.x}px`;
 	}
 
-	updateLayoutList(elList: HTMLUListElement | HTMLOListElement, list: Pick<Button, 'isActive' | 'getBounds'>[]) {
+	updateLayoutList(elList: HTMLUListElement | HTMLOListElement, list: Pick<AccessibilityButton, 'isActive' | 'getBounds'>[]): void {
 		this.rescueFocus(elList);
 		list.forEach((choice, index) => {
 			const elChoice = elList.children[index] as HTMLLIElement;
@@ -222,19 +222,19 @@ export default class Accessibility {
 		});
 	}
 
-	updateLayoutChoices() {
+	updateLayoutChoices(): void {
 		this.updateLayoutList(this.elChoices, this.state.choices);
 	}
 
-	updateLayoutButtons() {
+	updateLayoutButtons(): void {
 		this.updateLayoutList(this.elButtons, this.state.buttons);
 	}
 
-	updateLayoutSliders() {
+	updateLayoutSliders(): void {
 		this.updateLayoutList(this.elSliders, this.state.sliders);
 	}
 
-	rescueFocus(elContainer: HTMLElement) {
+	rescueFocus(elContainer: HTMLElement): void {
 		const elActive = document.activeElement;
 		if (elContainer === elActive) return;
 		if (!elActive || elContainer.contains(elActive)) {
@@ -242,7 +242,7 @@ export default class Accessibility {
 		}
 	}
 
-	updateLayout = () => {
+	updateLayout = (): void => {
 		this.updateLayoutContainer();
 		this.updateLayoutText();
 		this.updateLayoutChoices();
@@ -250,17 +250,17 @@ export default class Accessibility {
 		this.updateLayoutSliders();
 	};
 
-	text(text = '') {
+	text(text = ''): void {
 		this.state.text = text;
 		this.updateLayoutText();
 	}
 
-	name(name = '') {
+	name(name = ''): void {
 		this.state.name = name;
 		this.updateLayoutText();
 	}
 
-	button(button: Button) {
+	button(button: AccessibilityButton): void {
 		this.state.buttons.push(button);
 		const li = document.createElement('li');
 		li.style.position = 'absolute';
@@ -288,7 +288,7 @@ export default class Accessibility {
 		this.updateLayoutButtons();
 	}
 
-	slider(slider: Slider) {
+	slider(slider: AccessibilitySlider): void {
 		this.state.sliders.push(slider);
 		const li = document.createElement('li');
 		li.style.position = 'absolute';
@@ -316,14 +316,16 @@ export default class Accessibility {
 			input.style.color = 'transparent';
 			input.style.fontSize = '0';
 		}
-		input.onchange = event => slider.set(Number((event.currentTarget as HTMLInputElement).value));
-		input.onfocus = () => (input.value = slider.get().toString(10));
+		input.onchange = (event): void => slider.set(Number((event.currentTarget as HTMLInputElement).value));
+		input.onfocus = (): void => {
+			input.value = slider.get().toString(10);
+		};
 		li.appendChild(input);
 		this.elSliders.appendChild(li);
 		this.updateLayoutSliders();
 	}
 
-	choices(choices: Button[] = []) {
+	choices(choices: AccessibilityButton[] = []): void {
 		this.state.choices = choices;
 		this.rescueFocus(this.elChoices);
 		this.elChoices.innerHTML = '';

--- a/src/gui/a11y/Accessibility.ts
+++ b/src/gui/a11y/Accessibility.ts
@@ -1,0 +1,355 @@
+import RJS from '../../core/RJS';
+import { tokenizeTextStyle } from '../../utils/textStyle';
+
+interface Bounds {
+	x: number;
+	y: number;
+	width: number;
+	height: number;
+}
+
+interface Button {
+	label?: string;
+	isActive: () => boolean;
+	onclick: HTMLButtonElement['onclick'];
+	onfocus?: HTMLButtonElement['onfocus'];
+	onblur?: HTMLButtonElement['onblur'];
+	getBounds: () => Bounds;
+}
+
+interface Slider {
+	label?: string;
+	isActive: () => boolean;
+	min: number;
+	max: number;
+	step: number | 'any';
+	set: (value: number) => void;
+	get: () => number;
+	getBounds: () => Bounds;
+}
+
+/** sanitize strings for better screen-reading */
+function sanitize(str: string) {
+	return str.replace(/\s+/g, ' ').trim();
+}
+
+/** converts RenJS formatted text to an HTML markup string */
+function textToHtml(text: string) {
+	const tokens = tokenizeTextStyle(text);
+	const tags = [];
+	let result = '';
+	while (tokens.length) {
+		const token = tokens.shift();
+		if (token.tag) {
+			if (token.tag === 'end' && tags.length) {
+				result += `</${tags.pop()}>`;
+			} else if (token.tag.startsWith('color')) {
+				tags.push('mark');
+				result += '<mark>';
+			} else if (token.tag === 'bold') {
+				tags.push('strong');
+				result += '<strong>';
+			} else if (token.tag === 'italic') {
+				tags.push('em');
+				result += '<em>';
+			}
+		} else {
+			result += token.text;
+		}
+	}
+	return result.replace(/\n/g, '<br />');
+}
+
+/**
+ * Adds an accessible DOM layer on top of the game canvas
+ * in order to support keyboard navigation and screen-reading
+ */
+export default class Accessibility {
+	/** if debug is true, accessibility elements will be visible */
+	debug = false;
+
+	elContainer: HTMLDivElement;
+	elProgress: HTMLProgressElement;
+	elText: HTMLDivElement;
+	elChoices: HTMLOListElement;
+	elButtons: HTMLUListElement;
+	elSliders: HTMLUListElement;
+
+	state: {
+		name: string;
+		text: string;
+		choices: Button[];
+		buttons: Button[];
+		sliders: Slider[];
+	} = {
+		name: '',
+		text: '',
+		choices: [],
+		buttons: [],
+		sliders: [],
+	};
+
+	constructor(public game: RJS) {
+		this.elContainer = document.createElement('div');
+		this.elContainer.style.position = 'fixed';
+		this.elContainer.style.pointerEvents = 'none';
+		if (this.debug) {
+			this.elContainer.style.border = 'solid 1px red';
+		}
+
+		this.elProgress = document.createElement('progress');
+		this.elProgress.max = 100;
+		this.elProgress.value = 0;
+		if (!this.debug) {
+			this.elProgress.style.opacity = '0';
+		}
+
+		this.elChoices = document.createElement('ol');
+		this.elChoices.style.listStyle = 'none';
+
+		this.elButtons = document.createElement('ul');
+		this.elButtons.style.listStyle = 'none';
+
+		this.elSliders = document.createElement('ul');
+		this.elSliders.style.listStyle = 'none';
+
+		this.elText = document.createElement('div');
+		this.elText.setAttribute('aria-live', 'polite');
+		this.elText.setAttribute('aria-atomic', 'true');
+		this.elText.setAttribute('aria-relevant', 'text');
+		this.elText.setAttribute('role', 'main');
+		this.elText.setAttribute('aria-roledescription', 'text');
+		this.elText.tabIndex = 0;
+		this.elText.onclick = () => {
+			this.game.onTap(null);
+		};
+		this.elText.style.position = 'absolute';
+		if (this.debug) {
+			this.elText.style.color = 'red';
+			this.elText.style.top = '1rem';
+			this.elText.style.left = '1rem';
+			this.elText.style.right = '1rem';
+			this.elText.style.bottom = '1rem';
+		} else {
+			this.elText.style.color = 'transparent';
+			this.elText.style.fontSize = '0';
+			this.elText.style.outline = 'none';
+			this.elText.style.top = '0';
+			this.elText.style.left = '0';
+			this.elText.style.right = '0';
+			this.elText.style.bottom = '0';
+		}
+
+		this.elContainer.appendChild(this.elProgress);
+		this.elContainer.appendChild(this.elText);
+		this.elContainer.appendChild(this.elChoices);
+		this.elContainer.appendChild(this.elSliders);
+		this.elContainer.appendChild(this.elButtons);
+	}
+
+	boot() {
+		this.game.scale.onSizeChange.add(this.updateLayout);
+		this.updateLayout();
+		this.game.load.onLoadStart.add(() => {
+			this.updateLayout();
+			this.busy();
+			this.progress(0);
+		});
+		this.game.load.onLoadComplete.add(() => {
+			this.progress(100);
+			this.ready();
+		});
+		this.game.load.onFileComplete.add(progress => {
+			this.progress(progress);
+		});
+
+		document.body.appendChild(this.elContainer);
+	}
+
+	progress(progress) {
+		if (progress === undefined) {
+			delete this.elProgress.value;
+		} else {
+			this.elProgress.value = Math.floor(progress);
+		}
+	}
+
+	busy() {
+		this.elText.setAttribute('aria-busy', 'true');
+	}
+
+	ready() {
+		this.elText.setAttribute('aria-busy', 'false');
+	}
+
+	updateLayoutText() {
+		let text = textToHtml(
+			this.game.gui?.currentMenu !== 'hud'
+				? ''
+				: sanitize(this.state.text)
+						.split('\n')
+						.map(i => i.trim())
+						.filter(i => i)
+						.join('\n')
+		);
+
+		if (text.length > 0 && this.state.name) {
+			text = `${sanitize(this.state.name)}: ${text}`;
+		}
+		this.elText.innerHTML = text;
+	}
+
+	updateLayoutContainer() {
+		this.elContainer.style.width = `${this.game.scale.width}px`;
+		this.elContainer.style.height = `${this.game.scale.height}px`;
+		this.elContainer.style.top = `${this.game.scale.margin.top}px`;
+		this.elContainer.style.left = `${this.game.scale.margin.left}px`;
+	}
+
+	updateLayoutBounds(el: HTMLElement, rect: Bounds) {
+		el.style.width = `${rect.width * this.game.scale.scaleFactorInversed.x}px`;
+		el.style.height = `${rect.height * this.game.scale.scaleFactorInversed.y}px`;
+		el.style.top = `${rect.y * this.game.scale.scaleFactorInversed.y}px`;
+		el.style.left = `${rect.x * this.game.scale.scaleFactorInversed.x}px`;
+	}
+
+	updateLayoutList(elList: HTMLUListElement | HTMLOListElement, list: Pick<Button, 'isActive' | 'getBounds'>[]) {
+		this.rescueFocus(elList);
+		list.forEach((choice, index) => {
+			const elChoice = elList.children[index] as HTMLLIElement;
+			elChoice.style.display = choice.isActive() ? null : 'none';
+			this.updateLayoutBounds(elChoice, choice.getBounds());
+		});
+	}
+
+	updateLayoutChoices() {
+		this.updateLayoutList(this.elChoices, this.state.choices);
+	}
+
+	updateLayoutButtons() {
+		this.updateLayoutList(this.elButtons, this.state.buttons);
+	}
+
+	updateLayoutSliders() {
+		this.updateLayoutList(this.elSliders, this.state.sliders);
+	}
+
+	rescueFocus(elContainer: HTMLElement) {
+		const elActive = document.activeElement;
+		if (elContainer === elActive) return;
+		if (!elActive || elContainer.contains(elActive)) {
+			this.elText.focus();
+		}
+	}
+
+	updateLayout = () => {
+		this.updateLayoutContainer();
+		this.updateLayoutText();
+		this.updateLayoutChoices();
+		this.updateLayoutButtons();
+		this.updateLayoutSliders();
+	};
+
+	text(text = '') {
+		this.state.text = text;
+		this.updateLayoutText();
+	}
+
+	name(name = '') {
+		this.state.name = name;
+		this.updateLayoutText();
+	}
+
+	button(button: Button) {
+		this.state.buttons.push(button);
+		const li = document.createElement('li');
+		li.style.position = 'absolute';
+		const btn = document.createElement('button');
+		btn.style.position = 'absolute';
+		btn.style.top = '0';
+		btn.style.left = '0';
+		btn.style.width = '100%';
+		btn.style.height = '100%';
+		btn.style.background = 'transparent';
+		if (this.debug) {
+			btn.style.border = 'solid 1px red';
+			btn.style.color = 'red';
+		} else {
+			btn.style.border = 'none';
+			btn.style.color = 'transparent';
+			btn.style.fontSize = '0';
+		}
+		btn.textContent = button.label || `Button ${this.state.buttons.length}`;
+		btn.onclick = button.onclick;
+		btn.onfocus = button.onfocus;
+		btn.onblur = button.onblur;
+		li.appendChild(btn);
+		this.elButtons.appendChild(li);
+		this.updateLayoutButtons();
+	}
+
+	slider(slider: Slider) {
+		this.state.sliders.push(slider);
+		const li = document.createElement('li');
+		li.style.position = 'absolute';
+		const input = document.createElement('input');
+		input.type = 'number';
+		input.setAttribute('aria-label', slider.label || `Slider ${this.state.buttons.length}`);
+		input.min = slider.min.toString(10);
+		input.max = slider.max.toString(10);
+		input.step = slider.step.toString(10);
+		input.value = slider.get().toString(10);
+		input.style.position = 'absolute';
+		input.style.top = '0';
+		input.style.left = '0';
+		input.style.width = '100%';
+		input.style.height = '100%';
+		input.setAttribute('appearance', 'none');
+		input.style.background = 'transparent';
+		if (this.debug) {
+			input.style.border = 'solid 1px red';
+			input.style.color = 'red';
+		} else {
+			input.style.border = 'none';
+			input.style.color = 'transparent';
+			input.style.fontSize = '0';
+		}
+		input.onchange = event => slider.set(Number((event.currentTarget as HTMLInputElement).value));
+		input.onfocus = () => (input.value = slider.get().toString(10));
+		li.appendChild(input);
+		this.elSliders.appendChild(li);
+		this.updateLayoutSliders();
+	}
+
+	choices(choices: Button[] = []) {
+		this.state.choices = choices;
+		this.rescueFocus(this.elChoices);
+		this.elChoices.innerHTML = '';
+		choices.forEach(i => {
+			const li = document.createElement('li');
+			li.style.position = 'absolute';
+			const btn = document.createElement('button');
+			btn.style.position = 'absolute';
+			btn.style.top = '0';
+			btn.style.left = '0';
+			btn.style.width = '100%';
+			btn.style.height = '100%';
+			btn.style.background = 'transparent';
+			if (this.debug) {
+				btn.style.border = 'solid 1px red';
+				btn.style.color = 'red';
+			} else {
+				btn.style.border = 'none';
+				btn.style.color = 'transparent';
+				btn.style.fontSize = '0';
+			}
+			btn.innerHTML = textToHtml(i.label);
+			btn.onclick = i.onclick;
+			btn.onfocus = i.onfocus;
+			btn.onblur = i.onblur;
+			li.appendChild(btn);
+			this.elChoices.appendChild(li);
+		});
+		this.updateLayoutChoices();
+	}
+}

--- a/src/gui/elements/ChoiceHandler.ts
+++ b/src/gui/elements/ChoiceHandler.ts
@@ -66,6 +66,16 @@ export default class ChoiceHandler extends Graphics {
                 transition(null,this);
             },20)
 
+            this.game.accessibility.choices(
+                choices.map((choice, index) => ({
+                    label: choice.choiceText,
+                    isActive: () => !this.game.control.unskippable && this.boxes[index].parent.parent === this.game.gui.menus[this.game.gui.currentMenu],
+                    onclick: () => resolve(index),
+                    onfocus: () => this.boxes[index].frame = 1,
+                    onblur: () => this.boxes[index].frame = 0,
+                    getBounds: () => this.boxes[index].getBounds(),
+                }))
+            );
         })
 
     }
@@ -97,6 +107,7 @@ export default class ChoiceHandler extends Graphics {
     }
 
     async hide(transitionName?): Promise<any> {
+        this.game.accessibility.choices();
         if (!this.visible) return;
         if (!transitionName) transitionName = this.config.transition;
         const transition = this.game.screenEffects.transition.get(transitionName);

--- a/src/gui/elements/ChoiceHandler.ts
+++ b/src/gui/elements/ChoiceHandler.ts
@@ -3,6 +3,7 @@ import {Graphics,Button,Color} from 'phaser-ce';
 import BaseButton from './BaseButton';
 import {setTextStyles} from '../../utils/gui'
 import Label from './Label'
+import { AccessibilityBounds } from '../a11y/Accessibility';
 
 export default class ChoiceHandler extends Graphics {
 
@@ -69,11 +70,11 @@ export default class ChoiceHandler extends Graphics {
             this.game.accessibility.choices(
                 choices.map((choice, index) => ({
                     label: choice.choiceText,
-                    isActive: () => !this.game.control.unskippable && this.boxes[index].parent.parent === this.game.gui.menus[this.game.gui.currentMenu],
-                    onclick: () => resolve(index),
-                    onfocus: () => this.boxes[index].frame = 1,
-                    onblur: () => this.boxes[index].frame = 0,
-                    getBounds: () => this.boxes[index].getBounds(),
+                    isActive: (): boolean => !this.game.control.unskippable && this.boxes[index].parent.parent === this.game.gui.menus[this.game.gui.currentMenu],
+                    onclick: (): void => resolve(index),
+                    onfocus: (): void => { this.boxes[index].frame = 1; },
+                    onblur: (): void => { this.boxes[index].frame = 0; },
+                    getBounds: (): AccessibilityBounds => this.boxes[index].getBounds(),
                 }))
             );
         })

--- a/src/gui/elements/MessageBox.ts
+++ b/src/gui/elements/MessageBox.ts
@@ -96,6 +96,7 @@ export default class MessageBox extends Sprite{
     // when whole text is displayed, show click to continue and wait for click
     // when player clicks, message box is hid with transition and action ends
     show(text,sfx?): Promise<any> {
+        this.game.accessibility.text(text);
         if (sfx === 'none'){
             // if character voice configured as none, don't make any sound
             sfx = null;
@@ -218,6 +219,7 @@ export default class MessageBox extends Sprite{
     }
 
     async hide(transitionName?): Promise<any>{
+        this.game.accessibility.text();
         if (!this.visible) return;
         if (!transitionName) transitionName = this.config.transition;
         const transition = this.game.screenEffects.transition.get(transitionName);

--- a/src/gui/elements/NameBox.ts
+++ b/src/gui/elements/NameBox.ts
@@ -36,6 +36,7 @@ export default class NameBox extends Sprite {
     }
 
     async show(text: string,color: string): Promise<any> {
+        this.game.accessibility.name(text);
         this.text.setText(text, true);
         this.text.updateTransform();
         if (this.config.tintStyle === 'box'){
@@ -50,6 +51,7 @@ export default class NameBox extends Sprite {
     }
 
     async hide(transitionName?: string): Promise<any>{
+        this.game.accessibility.name();
         if (!this.visible) return;
         if (!transitionName) transitionName = this.config.transition;
         const transition = this.game.screenEffects.transition.get(transitionName);

--- a/src/gui/elements/RJSLoadingScreen.ts
+++ b/src/gui/elements/RJSLoadingScreen.ts
@@ -32,7 +32,7 @@ export default class RJSLoadingScreen {
         }
     }
 
-    setLoadingBar(game): void{
+    setLoadingBar(game: RJS): void{
         if (!this.loadingBar) return;
         const dir = game.config.loadingScreen.loadingBar.direction ? game.config.loadingScreen.loadingBar.direction : 0;
         game.load.setPreloadSprite(this.loadingBar,dir);
@@ -44,7 +44,7 @@ export default class RJSLoadingScreen {
         }
     }
 
-    destroy(game): void {
+    destroy(game: RJS): void {
         if (game.config.loadingScreen.fade){
             const tween: Tween = game.add.tween(this.container).to({alpha:0},500);
             tween.onComplete.addOnce(()=>{

--- a/src/states/Boot.ts
+++ b/src/states/Boot.ts
@@ -18,6 +18,7 @@ class Boot extends RJSState {
     init(): void {
         this.game.setupScreen();
         this.game.sound.boot();
+        this.game.accessibility.boot();
     }
 
     preload (): void {

--- a/src/utils/textStyle.ts
+++ b/src/utils/textStyle.ts
@@ -1,0 +1,19 @@
+type Token = { text: string; tag?: never } | { text?: never; tag: string };
+
+const re = /\((?:color:(?:\w+|#[0-9a-fA-F]{3}|#[0-9a-fA-F]{6})|italic|bold|end)\)/;
+
+/** converts text into a list of tokens that can be used to construct styles */
+export function tokenizeTextStyle(text: string): Token[] {
+	const styles: Token[] = [];
+	while (true) {
+		const match = re.exec(text);
+		if (!match) {
+			styles.push({ text });
+			return styles;
+		}
+		const { index, 0: tag } = match;
+		styles.push({ text: text.substr(0, index) });
+		styles.push({ tag: tag.slice(1, -1) });
+		text = text.substr(index + tag.length);
+	}
+}


### PR DESCRIPTION
fixes #37 

First pass at adding a mostly-invisible accessibility layer on top of the game canvas to support keyboard navigation and screen-reading. All interactive elements including choices, visual choices, menu buttons, sliders, and a text container have corresponding DOM elements which are updated to match their labels, positions, and interactions. These elements have inline CSS applied which allows their focus outline to be seen (except the text), but keeps the rest of the element hidden.

Screen-reading tested with [NVDA](https://github.com/nvaccess/nvda).

Known issues:
- The default tab navigation order won't always be visually intuitive: the DOM elements will be in the same order as the GUI element definitions. Previously, the save menu's "return" button was first instead of last, and the HUD menu buttons were RTL instead of LTR. I've updated the ones in the repo, but since the GUI is user-defined, the order may still be "incorrect" if users aren't aware of this.
- If using tab navigation and a screen-reader, the first text shown immediately after a choice may be spoken twice (the screen-reader may speak due to the focus change from the choice list to the text element, and then again due to the text element live region updating with new text). Not sure if there's a way to avoid this without removing the focus modification, and that would lead to focus always being lost after choices which seems like significantly worse UX. 
- If using the screen-reader browse mode controls to select elements, the focus can end up in a weird state where the first HUD menu button will always receive focus after a choice. I'm not familiar enough with browse mode to know if this is solvable with the current approach, but it's hopefully an edge case since the entire accessibility layer supports tab navigation.
- Accessible labels for visual choices, menu buttons, and sliders are created using internal names, not authored content. As discussed on discord, a second pass can introduce a new file like `LANG/a11y.yml` which will allow these to be overridden + localized.
- The semantic HTML used in text and choice labels to match the RenJS formatting tags is not accurate in nested cases (#71 fixes this)