### PR TITLE
fix(a11y): escape html before tokenizing it for accessible label

### DIFF
--- a/src/gui/a11y/Accessibility.ts
+++ b/src/gui/a11y/Accessibility.ts
@@ -45,9 +45,15 @@ function sanitize(str: string): string {
 	return str.replace(/\s+/g, ' ').trim();
 }
 
+function escapeHTML(html) {
+	const el = document.createElement('div');
+	el.textContent = html;
+	return el.innerHTML;
+}
+
 /** converts RenJS formatted text to an HTML markup string */
 function textToHtml(text: string): string {
-	const tokens = tokenizeTextStyle(text);
+	const tokens = tokenizeTextStyle(escapeHTML(text));
 	const tags = [];
 	let result = '';
 	while (tokens.length) {


### PR DESCRIPTION
avoids issues caused by the accessible labels assigning text using `innerHTML` in order to parse the tags added as part of the tokenization process