### PR TITLE
Enable simple strict type checking options

### DIFF
--- a/src/gui/elements/MessageBox.ts
+++ b/src/gui/elements/MessageBox.ts
@@ -117,7 +117,7 @@ export default class MessageBox extends Sprite{
             if (this.ctc){
                 this.ctc.visible = true;
             }
-            return;
+            return Promise.resolve(true);
         }
         this.text.setText('', true);
 

--- a/src/managers/LogicManager.ts
+++ b/src/managers/LogicManager.ts
@@ -3,11 +3,21 @@ import RJS from '../core/RJS';
 import RJSManagerInterface from './RJSManager';
 import StoryAction from '../core/actions/StoryAction';
 
+type Choice = {
+    index: any,
+    actions: any[],
+    available: boolean,
+    choiceText: string,
+    previouslyChosen: boolean,
+    interrupt?: boolean,
+    origin?: any,
+};
+
 export interface LogicManagerInterface<T> extends RJSManagerInterface {
     choicesLog: object;
     vars: object;
 
-    currentChoices: any[];
+    currentChoices: Choice[];
     // interrupting: boolean;
     visualChoices?: T;
 }
@@ -15,7 +25,7 @@ export interface LogicManagerInterface<T> extends RJSManagerInterface {
 export default class LogicManager implements LogicManagerInterface<Group> {
     choicesLog: object;
     vars: object = {};
-    currentChoices: any[];
+    currentChoices: Choice[];
     interrupting?: {origin: number;execId: string};
     showingText = false;
 
@@ -101,9 +111,9 @@ export default class LogicManager implements LogicManagerInterface<Group> {
         return text;
     }
 
-    parseChoice(index,choice): any {
+    parseChoice(index: number, choice): Choice {
         const rawText = Object.keys(choice)[0];
-        const parsedChoice: any = {
+        const parsedChoice: Choice = {
             index,
             actions: choice[rawText] || [],
             available: true,
@@ -125,7 +135,7 @@ export default class LogicManager implements LogicManagerInterface<Group> {
 
 
 
-    async choose(index): Promise<any> {
+    async choose(index: number): Promise<void> {
         const chosenOption = this.currentChoices[index];
         // update choice log
         this.updateChoiceLog(chosenOption.index);
@@ -188,7 +198,7 @@ export default class LogicManager implements LogicManagerInterface<Group> {
         return false;
     }
 
-    async showChoices(boxId,choices): Promise<boolean> {
+    async showChoices(boxId: string, choices: any[]): Promise<void> {
         this.showingText = await this.checkTextAction(choices[0]);
         if (this.showingText){
             choices.shift();
@@ -205,7 +215,6 @@ export default class LogicManager implements LogicManagerInterface<Group> {
             chosenIdx = await this.game.gui.hud.showChoices(boxId,this.currentChoices);
         }
         this.choose(chosenIdx);
-        return;
     }
 
     interrupt(boxId, choices): any {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,9 @@
 {
   "compilerOptions": {
+    "noImplicitReturns": true,
+    "noImplicitThis": true,
+    "strictBindCallApply": true,
+    "strictFunctionTypes": true,
     "target": "es5",
     "sourceMap": true,
 //    "allowJs": true,


### PR DESCRIPTION
:wave: I was trying to work on some tooling for my VN using the codebase, and was getting turned around with the minimal use of type annotations.  I took a stab at adding improving the situation, which I'm splitting across multiple PRs to avoid flooding the project with changes.  I hope improvements to the typing of the codebase are welcome, as they've helped me understand the engine better.

---

This set of options guarantees:
* All functions that return a value actually do return a value
* `this` is associated with a specific type (not `any`)
* `call`/`bind`/`apply`ed functions are called correctly
* Function param and arg types match

Compliance with stricter type checks requires the following fixes:
* Fix incorrect return in `MessageBox.show`
* Tighten types on `LogicManager.choose` and `LogicManager.showChoices`

This change also introduces the `Choice` type for use within `LogicManager`
(assigns a strict type to `LogicManager.currentChoices`).