### PR TITLE
Require all managers to be defined

### DIFF
--- a/src/core/RJS.ts
+++ b/src/core/RJS.ts
@@ -59,10 +59,10 @@ export default class RJS extends Game {
     interruptAction: any = null
 
     managers: {
-        background?: BackgroundManager;
-        character?: CharacterManager;
+        background: BackgroundManager;
+        character: CharacterManager;
         audio: AudioManager;
-        cgs?: CGSManager;
+        cgs: CGSManager;
         text: TextManager;
         tween: TweenManager;
         logic: LogicManager;


### PR DESCRIPTION
undefined managers was originally introduced in a refactor that had
code to `initModulesInOrder`; three of the managers could not be
calculated when following that code path. That code was never used and
has since been removed, but the optional manager typing remained.

Static analysis shows no place in the current code where a manager
could be undefined. By marking that in the type system, it simplifies
logic in other locations that would otherwise have to treat each
manager as optional.
