### PR TITLE
Update managers to comply with strict typing

### DIFF
--- a/docs/docs-page.html
+++ b/docs/docs-page.html
@@ -2154,7 +2154,7 @@ start:
 							</ul></li>
 							<li><strong>Audio</strong>: Access this manager through <i>this.managers.audio</i>. This manager takes care of all the audio of the story.
 							<ul>
-								<li><strong>Current Music and Sound</strong>: You can obtain the <strong>Phaser.Sound</strong> objects for <strong>bgm</strong>(background music) and <strong>bgs</strong> (background sound) with <i>this.managers.audio.current</i>.</li>
+								<li><strong>Current Music and Sound</strong>: You can obtain the <strong>Phaser.Sound</strong> objects for all music and sounds with <i>this.managers.audio.current</i>. The background music is available under the <i>bgm</i> key; all other sounds have their own unique key names (you can find all of them using <i>Object.keys(this.managers.audio.current)</i>).</li>
 							</ul></li>
 							<li><strong>Logic</strong>: Access this manager through <i>this.managers.logic</i>. This manager takes care of the permanent variables set with the <a href="#var-action">Var Action</a>, and branching the story by way of choices and ifs.
 							<ul>

--- a/src/core/RJS.ts
+++ b/src/core/RJS.ts
@@ -32,7 +32,7 @@ export default class RJS extends Game {
     xShots = []
     blackOverlay: Graphics
     setup: any
-    story: object
+    story: {[key: string]: any}
     guiSetup: any
     gui: RJSGUI
     tools: any = {}
@@ -158,7 +158,6 @@ export default class RJS extends Game {
 
 
         // init game and start main menu
-        this.managers.story.setupStory()
         await this.gui.init();
 
         this.initInput();

--- a/src/core/RJSTween.ts
+++ b/src/core/RJSTween.ts
@@ -1,6 +1,6 @@
 import {Tween} from 'phaser-ce'
 export default class RJSTween extends Tween {
 
-	tweenables?: {}
+	tweenables?: {[key: string]: any}
 	callbackOnComplete?: any
 }

--- a/src/gui/RJSHUD.ts
+++ b/src/gui/RJSHUD.ts
@@ -10,8 +10,8 @@ import { changeInputEnabled, hudSort } from '../utils/gui';
 import { AccessibilityBounds } from './a11y/Accessibility';
 
 export default class RJSHUD extends RJSMenu {
-    mBoxes = {}
-    nBoxes = {}
+    mBoxes: {[key: string]: MessageBox} = {}
+    nBoxes: {[key: string]: NameBox} = {}
     cHandlers: { [key: string]: ChoiceHandler } = {}
 
     skipClickArea: Phaser.Rectangle[] = []

--- a/src/managers/AudioManager.ts
+++ b/src/managers/AudioManager.ts
@@ -42,7 +42,7 @@ export default class AudioManager implements AudioManagerInterface {
        return this.active;
     }
 
-    play (key:string,type:string='bgm',looped=false,fromSeconds:number|null=null,transition='FADE',force=false): void {
+    play (key:string,type='bgm',looped=false,fromSeconds:number|null=null,transition='FADE',force=false): void {
         if (!force && this.current[type] && this.current[type]?.key === key && this.current[type]?.isPlaying){
             // music is the same, and it's playing, do nothing
             return;

--- a/src/managers/AudioManager.ts
+++ b/src/managers/AudioManager.ts
@@ -1,44 +1,53 @@
 import RJSManagerInterface from './RJSManager';
 import RJS from '../core/RJS';
 
+export type CurrentAudio = {
+    bgm: Phaser.Sound | null;
+    bgs: Phaser.Sound | null;
+}
+
+export type ActiveAudio = {
+    bgm: {key:string,looped:boolean,fromSeconds:number|null,transition:string}|null;
+    bgs: {key:string,looped:boolean,fromSeconds:number|null,transition:string}|null;
+}
+
+const AUDIO_TYPES: ('bgm' | 'bgs')[] = ['bgm', 'bgs'];
+
 export interface AudioManagerInterface extends RJSManagerInterface {
-    play(key: string, type: string, looped: boolean, fromSeconds: number, transition: string): void;
+    play(key: string, type?: 'bgm'|'bgs', looped?: boolean, fromSeconds?: number | null, transition?: string): void;
     stop (type: string, transition: string): void;
     playSFX (key: string): void;
-    isMusic(actor): boolean;
-    isSfx(actor): boolean;
-    decodeAudio(audioList): Promise<any>;
+    isMusic(actor: string): boolean;
+    isSfx(actor: string): boolean;
+    decodeAudio(audioList: string[]): Promise<void>;
     mute(mute: boolean): void;
-    changeVolume(volume): void;
+    changeVolume(): void;
     stopAll(): void;
-    getActive(): object;
-    current: {
-        bgm: Phaser.Sound;
-        bgs: Phaser.Sound;
-    };
+    getActive(): ActiveAudio;
+    current: CurrentAudio;
     // audioLoaded: boolean;
 }
 
 export default class AudioManager implements AudioManagerInterface {
-    current = { bgm: null, bgs: null };
-    active = { bgm: null, bgs: null };
+    current: CurrentAudio = { bgm: null, bgs: null };
+    active: ActiveAudio = { bgm: null, bgs: null };
 
-    private sfxCache = {};
+    private sfxCache: {[key: string]: Phaser.Sound} = {};
     // audioLoaded: boolean;
     private game: RJS
-    private unavailableAudio: string[];
+    private unavailableAudio: string[] = [];
 
     constructor(game: RJS) {
         this.game = game
         this.changeVolume()
     }
 
-    getActive(): object{
+    getActive(): ActiveAudio {
        return this.active;
     }
 
-    play (key,type='bgm',looped=false,fromSeconds=null,transition='FADE',force=false): void {
-        if (!force && this.current[type] && this.current[type].key === key && this.current[type].isPlaying){
+    play (key:string,type:'bgm'|'bgs'='bgm',looped=false,fromSeconds:number|null=null,transition='FADE',force=false): void {
+        if (!force && this.current[type] && this.current[type]?.key === key && this.current[type]?.isPlaying){
             // music is the same, and it's playing, do nothing
             return;
         }
@@ -63,31 +72,32 @@ export default class AudioManager implements AudioManagerInterface {
         if (looped && fromSeconds){
             marker = 'intro';
             // looped = false;
-            music.addMarker(marker,0,fromSeconds,null,false);
+            music.addMarker(marker,0,fromSeconds,undefined,false);
             music.onMarkerComplete.addOnce(()=>{
-                music.addMarker('looped',fromSeconds,music.totalDuration-fromSeconds,null,true);
+                music.addMarker('looped',fromSeconds,music.totalDuration-fromSeconds,undefined,true);
                 music.play('looped');
                 music.volume = volume;
             })
         }
 
-        music.play(marker,0,null,looped);
+        music.play(marker,0,undefined,looped);
         // volume has to be set after it starts or it will ignore it
 
         if (transition === 'FADE'){
             music.volume = 0;
-            this.game.add.tween(music).to({volume},1500,null,true);
+            this.game.add.tween(music).to({volume},1500,undefined,true);
         } else {
             music.volume = volume;
         }
     }
 
-    stop(type: string, transition = 'FADE'): void {
-        if (!this.current[type]){
+    stop(type: 'bgm' | 'bgs', transition = 'FADE'): void {
+        const sound = this.current[type];
+        if (!sound){
             return;
         }
         if (!this.game.userPreferences.get('muted')) {
-            this.stopAudio(this.current[type],transition);
+            this.stopAudio(sound,transition);
             this.current[type]=null;
             this.active[type]=null;
         }
@@ -104,7 +114,7 @@ export default class AudioManager implements AudioManagerInterface {
         }
     }
 
-    playSFX(key,volume?): void {
+    playSFX(key: string, volume?: number): void {
         if (this.unavailableAudio.includes(key)) {
           console.warn(
             `SFX related to key ${key} is unavailable for playback.`
@@ -119,11 +129,13 @@ export default class AudioManager implements AudioManagerInterface {
         }
     }
 
-    set (active): void {
-        for (const type of ['bgm','bgs']){
-
-            if (!active[type]) continue;
-            this.play(active[type].key,type,active[type].looped,active[type].fromSeconds,active[type].transition);
+    set (active: ActiveAudio): void {
+        for (const type of AUDIO_TYPES){
+            const activeAudio = active[type];
+            if (!activeAudio) {
+                continue;
+            }
+            this.play(activeAudio.key,type,activeAudio.looped,activeAudio.fromSeconds,activeAudio.transition);
         }
     }
 
@@ -139,7 +151,7 @@ export default class AudioManager implements AudioManagerInterface {
         }
     }
 
-    async decodeAudio(audioList: string[]): Promise<any> {
+    async decodeAudio(audioList: string[]): Promise<void> {
         const availableAudios = audioList.filter(audio => this.game.cache.checkSoundKey(audio));
         this.unavailableAudio = audioList.filter(audio => !this.game.cache.checkSoundKey(audio));
 
@@ -147,17 +159,17 @@ export default class AudioManager implements AudioManagerInterface {
         return new Promise(resolve=>{
             this.game.sound.setDecodedCallback(availableAudios, () => {
               // this.audioLoaded = true;
-              resolve(true);
+              resolve();
             });
         })
 
     }
 
-    isMusic(actor): boolean {
+    isMusic(actor: string): boolean {
         return this.game.setup.music && actor in this.game.setup.music
     }
 
-    isSfx(actor): boolean {
+    isSfx(actor: string): boolean {
         return this.game.setup.sfx && actor in this.game.setup.sfx
     }
 

--- a/src/managers/BackgroundManager.ts
+++ b/src/managers/BackgroundManager.ts
@@ -21,8 +21,8 @@ export default class BackgroundManager implements RJSSpriteManagerInterface {
         bg.anchor.set(0.5);
         if (str.length !== 1){
             const framerate = str.length === 4 ? parseInt(str[3], 10) : 16;
-            bg.animations.add('run', null, framerate);
-            bg.animations.play('run', null, true);
+            bg.animations.add('run', undefined, framerate);
+            bg.animations.play('run', undefined, true);
         }
         return bg
     }
@@ -32,7 +32,7 @@ export default class BackgroundManager implements RJSSpriteManagerInterface {
             this.current.destroy();
         }
         if (!name){
-            this.current = null;
+            this.current = undefined;
             return;
         }
         this.current = this.createBackground(name);
@@ -40,9 +40,9 @@ export default class BackgroundManager implements RJSSpriteManagerInterface {
         this.current.visible = true;
     }
 
-    async show (name: string, transitionName: string): Promise<void> {
+    async show (name: string | null, transitionName: string): Promise<void> {
         const oldBg = this.current;
-        this.current = name ? this.createBackground(name) : null;
+        this.current = name ? this.createBackground(name) : undefined;
         if (this.current){
             this.current.visible=true;
         }

--- a/src/managers/CharacterManager.ts
+++ b/src/managers/CharacterManager.ts
@@ -4,21 +4,21 @@ import Character from '../entities/Character';
 import RJS from '../core/RJS';
 
 export interface CharacterManagerInterface extends RJSSpriteManagerInterface {
-    characters: object;
+    characters: {[key: string]: any};
     showing: object;
-    hideAll(transition: string);
+    hideAll(transition: string): Promise<void>;
     // add(name, displayName, speechColour, looks): void;
-    show(name, transition, props): any;
-    hide(name, transition): Promise<any>;
-    isCharacter(actor): boolean;
+    show(name: string, transitionName?: string, props?: any): any;
+    hide(name: string, transitionName?: string): Promise<void>;
+    isCharacter(actor: string): boolean;
 }
 
 
 
 export default class CharacterManager implements CharacterManagerInterface {
 
-    characters = {};
-    transition: Transition
+    characters: {[key: string]: any} = {};
+    transition?: Transition
 
     constructor(private game: RJS) {
         // this.characters = this.game.setup.characters;
@@ -42,7 +42,7 @@ export default class CharacterManager implements CharacterManagerInterface {
     }
 
     get showing(): { [key: string]: {look: string; position: {x: number;y: number}; flipped: boolean}}{
-        const showing = {}
+        const showing: {[key: string]: any} = {};
         for( const name in this.characters){
             if (this.characters[name].currentLook){
                 showing[name] = this.characters[name].getLookData();
@@ -51,7 +51,7 @@ export default class CharacterManager implements CharacterManagerInterface {
         return showing;
     }
 
-    async set (showing): Promise<any> {
+    async set (showing: {[key: string]: any}): Promise<any> {
         await this.hideAll(Transition.CUT);
         for (const name in showing) {
             const props = showing[name];
@@ -64,7 +64,7 @@ export default class CharacterManager implements CharacterManagerInterface {
         }
     }
 
-    async show(name, transitionName?, props?): Promise<any> {
+    async show(name: string, transitionName?: string, props?: any): Promise<any> {
         const character = this.characters[name];
         // grab old look to transition
         const oldLook = character.currentLook;
@@ -73,11 +73,11 @@ export default class CharacterManager implements CharacterManagerInterface {
         if (!transitionName) {
             transitionName = this.getDefaultTransition();
         }
-        await this.transition.get(transitionName)(oldLook, newLook, {x:newLook.x,y:newLook.y},newLook.scale.x);
+        await this.transition?.get(transitionName)(oldLook, newLook, {x:newLook.x,y:newLook.y},newLook.scale.x);
         if (oldLook) oldLook.destroy();
     }
 
-    async hide(name, transitionName): Promise<any> {
+    async hide(name: string, transitionName?: string): Promise<void> {
         if (!transitionName) {
             transitionName = this.getDefaultTransition();
         }
@@ -86,19 +86,19 @@ export default class CharacterManager implements CharacterManagerInterface {
         ch.lastScale = 1;
         ch.currentLook = null;
         delete this.showing[name];
-        await this.transition.get(transitionName)(oldLook,null);
+        await this.transition?.get(transitionName)(oldLook,null);
         if (oldLook) oldLook.destroy();
     }
 
-    async hideAll(transitionName?): Promise<any> {
+    async hideAll(transitionName?: string): Promise<void> {
         const promises = []
         for (const char in this.showing){
             promises.push(this.hide(char,transitionName));
         }
-        return Promise.all(promises)
+        await Promise.all(promises);
     }
 
-    isCharacter(actor): boolean {
+    isCharacter(actor: string): boolean {
         return actor in this.characters || actor === 'CHARS' || actor === 'ALL';
     }
 

--- a/src/managers/LogicManager.ts
+++ b/src/managers/LogicManager.ts
@@ -1,7 +1,6 @@
 import {Group} from 'phaser-ce';
 import RJS from '../core/RJS';
 import RJSManagerInterface from './RJSManager';
-import StoryAction from '../core/actions/StoryAction';
 
 type Choice = {
     index: any,

--- a/src/managers/RJSManager.ts
+++ b/src/managers/RJSManager.ts
@@ -1,9 +1,9 @@
 export default interface RJSManagerInterface {
-    set(...args: any);
+    set(...args: any): any;
 }
 
 export interface RJSSpriteManagerInterface extends RJSManagerInterface {
-    set(...args: any);
-    show (name, transition, props): any;
-    hide (name,transition): any;
+    set(...args: any): any;
+    show (name: string, transitionName: string, props: any): any;
+    hide (name: string, transitionName: string): any;
 }

--- a/src/managers/TweenManager.ts
+++ b/src/managers/TweenManager.ts
@@ -2,16 +2,16 @@ import RJS from '../core/RJS';
 import RJSTween from '../core/RJSTween';
 
 export interface TweenManagerInterface {
-    tween (sprite, tweenables, callback, time: number, start: boolean, delay?: number, unskippable?: boolean);
-    chain (tweens: any[], unskippable: boolean, time?: number);
-    skip(): any;
+    tween (sprite: any, tweenables: {[key: string]: any}, callback: () => void, time: number, start: boolean, delay?: number, unskippable?: boolean): RJSTween;
+    chain (tweens: any[], unskippable: boolean, time?: number): void;
+    skip(): void;
     current: RJSTween[];
 
 
 }
 
 export default class TweenManager implements TweenManagerInterface {
-    current = []
+    current: RJSTween[] = []
     private game: RJS
 
 
@@ -19,7 +19,7 @@ export default class TweenManager implements TweenManagerInterface {
         this.game = game
     }
 
-    tween(sprite, tweenables, callback, time, start, delay = 0, unskippable = false): RJSTween {
+    tween(sprite: any, tweenables: {[key: string]: any}, callback: () => void, time: number | undefined, start: boolean, delay = 0, unskippable = false): RJSTween {
         const tween: RJSTween = this.game.add.tween(sprite);
         tween.to(tweenables, time, Phaser.Easing.Linear.None,false, delay);
         if (callback) {
@@ -50,11 +50,11 @@ export default class TweenManager implements TweenManagerInterface {
 
     }
 
-    chain(tweens, unskippable = false, time?): void {
+    chain(tweens: any[], unskippable = false, time?: number): void {
         this.current = [];
-        let lastTween = null;
+        let lastTween: RJSTween | null = null;
         tweens.forEach(tw => {
-            const t = tw.time ? tw.time : time/tweens.length;
+            const t = tw.time ? tw.time : (time === undefined ? undefined : time/tweens.length);
             const tween = this.tween(tw.sprite, tw.tweenables, tw.callback, t, false, tw.delay);
             if (lastTween){
                 lastTween.chain(tween);
@@ -68,7 +68,7 @@ export default class TweenManager implements TweenManagerInterface {
         }
     }
 
-    parallel (tweens, unskippable = false, time?): void {
+    parallel (tweens: any[], unskippable = false, time?: number): void {
         this.current = [];
         tweens.forEach(tw => {
             this.tween(tw.sprite,tw.tweenables,tw.callback,time,true,tw.delay);


### PR DESCRIPTION
Thank you for your time in looking at these changes.
I'm trying to work in manageable chunks to not spam the project with PRs.

---

Three changes are less trivial then just adding some typing code:

* The `AudioManager` works with specific types of audio that can be
  typed with string literals (instead of arbitrary strings).
* `StoryManager.setupStory` deferred initialising some class properties
  which allowed for potentially undefined values.
* Phaser is typed to accept "undefined" for unknown values, but was
  getting passed "null" in some places.

Otherwise, it's pretty standard typing fixes, some of which make the
code more crash-resistant:

* Avoid performing math or calling methods on `undefined`
* Convert some objects ({}) to mapped types ({string:value})
* Assign custom types to AudioManager properties
* Add explicit types to manager function definitions