### PR TITLE
fix: credits/background colour issues

### DIFF
--- a/src/core/RJS.ts
+++ b/src/core/RJS.ts
@@ -135,6 +135,7 @@ export default class RJS extends Game {
     }
 
     async initStory(): Promise<any> {
+        this.stage.backgroundColor = this.storyConfig.backgroundColor || 0;
         this.userPreferences = new UserPreferences(this,this.storyConfig.userPreferences);
 
         this.managers = {

--- a/src/core/RJSGameConfig.ts
+++ b/src/core/RJSGameConfig.ts
@@ -12,7 +12,7 @@ export interface RJSGameConfig extends IGameConfig {
     name: string;
     w: number;
     h: number;
-    backgroundColor: number;
+    backgroundColor?: number;
     loadingScreen: {
         minTime?: number;
         background: string;

--- a/src/screen-effects/Effects.ts
+++ b/src/screen-effects/Effects.ts
@@ -1,6 +1,7 @@
 import RJSScreenEffectInterface from './RJSScreenEffect';
 import {AudioManagerInterface} from '../managers/AudioManager';
 import {TweenManagerInterface} from '../managers/TweenManager';
+import { Color } from 'phaser-ce';
 import RJS from '../core/RJS';
 import {setTextStyles} from '../utils/gui'
 
@@ -36,7 +37,14 @@ export default class Effects implements RJSScreenEffectInterface {
             this.audioManager.play(params.music, 'bgm', true, null, 'FADE');
         }
 
-        const style = this.game.gui.hud.cHandlers.default.config.text.style;
+        const style = { ...this.game.gui.hud.cHandlers.default.config.text.style };
+
+        // use a text color that contrasts with the bg
+        const { backgroundColor = 0 } = this.game.storyConfig;
+        const bgColor = typeof backgroundColor === 'string' ? Color.hexToColor(backgroundColor) : Color.getRGB(backgroundColor);
+        const textColor = Color.RGBtoHSV(bgColor.r, bgColor.g, bgColor.b).v > 0.5 ? Color.BLACK : Color.WHITE;
+        style.fill = Color.getWebRGB(textColor);
+
         const credits = this.game.add.text(this.game.world.centerX, this.game.config.h + 30, ' ', style);
         credits.anchor.set(0.5);
         const separation = credits.height + 10;

--- a/src/screen-effects/Transition.ts
+++ b/src/screen-effects/Transition.ts
@@ -140,8 +140,8 @@ export default class Transition implements RJSScreenEffectInterface {
     }
 
     async FADETOBG (from, to, position?, scaleX?): Promise<void> {
-        const bgColor = this.game.config.backgroundColor;
-        return this.FADETOCOLOUR(from, to, bgColor, position, scaleX)
+        const { backgroundColor = 0 } = this.game.config;
+        return this.FADETOCOLOUR(from, to, backgroundColor, position, scaleX)
     }
 }
 


### PR DESCRIPTION
- fixes issue where `backgroundColor` is not actually applied
- makes credits automatically pick white or black based on contrasting against `backgroundColor` (previously would inherit the game's text style, which isn't necessarily legible since it has other GUI element sitting between it and the background)
- flags `backgroundColor` type as optional

note that there is a workaround for this rn, which is that you can wrap individual lines of your credits text with `color` tags; this should still work as an override for the automatic colour selection here