### PR TITLE
fix: log unknown effects to console

### DIFF
--- a/src/core/actions/StoryActionEffect.ts
+++ b/src/core/actions/StoryActionEffect.ts
@@ -21,6 +21,7 @@ export default class StoryActionEffect extends StoryAction {
     		this.game.pluginsRJS[this.actor].onCall(this.params);
             // plugins resolve themselves
     	} else {
+            console.warn(`Effect "${this.actor}" is unknown.`);
             this.resolve();
         }
 


### PR DESCRIPTION
should help in case where user typos an effect name

(this can be particularly confusing in the case of a `ROLLINGCREDITS` typo bc the game softlocks in addition to not playing the animation since it also relies on the effect to actually end the game)